### PR TITLE
feat(home): hero, features, product highlights

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,65 @@
+import Link from "next/link";
+import Image from "next/image";
+import { Section } from "@/components/Section";
+import products from "@/data/products.json";
+
 export default function Home() {
+  const highlights = products.slice(0, 3);
   return (
-    <main className="min-h-screen flex items-center justify-center">
-      <h1 className="text-3xl font-bold">Welcome to Club Fore</h1>
-    </main>
+    <>
+      <Section className="py-24">
+        <div className="grid md:grid-cols-2 gap-8 items-center">
+          <div>
+            <h1 className="text-4xl md:text-5xl font-semibold tracking-tight">Precision meets power.</h1>
+            <p className="mt-4 text-lg opacity-80">
+              Sleek padel gear engineered for control and built to last.
+            </p>
+            <div className="mt-8 flex gap-3">
+              <Link className="px-5 py-3 bg-black text-white rounded-2xl border" href="/products">Shop Paddles</Link>
+              <Link className="px-5 py-3 border rounded-2xl" href="/contact">Contact</Link>
+            </div>
+          </div>
+          <div className="border rounded-2xl p-6 bg-white">
+            <Image src="/logo.svg" width={800} height={400} alt="Club Fore wordmark" className="w-full h-auto" />
+          </div>
+        </div>
+      </Section>
+
+      <Section>
+        <div className="grid md:grid-cols-3 gap-6">
+          {[
+            { title: "Control", text: "Balanced frames for surgical placement." },
+            { title: "Vibration dampening", text: "Composite layups reduce arm fatigue." },
+            { title: "Sustainable build", text: "Durable materials for a longer lifecycle." }
+          ].map((f) => (
+            <div key={f.title} className="border rounded-2xl p-6">
+              <h3 className="font-medium">{f.title}</h3>
+              <p className="opacity-70 text-sm mt-2">{f.text}</p>
+            </div>
+          ))}
+        </div>
+      </Section>
+
+      <Section>
+        <div className="flex items-baseline justify-between mb-6">
+          <h2 className="text-2xl font-semibold">Highlights</h2>
+          <Link href="/products" className="text-sm underline">View all</Link>
+        </div>
+        <div className="grid md:grid-cols-3 gap-6">
+          {highlights.map((p) => (
+            <Link key={p.id} href={`/products/${p.slug}`} className="border rounded-2xl p-4 hover:opacity-80">
+              <Image src={p.images[0]} alt={p.name} width={600} height={400} className="w-full h-auto rounded-xl border" />
+              <div className="mt-3 flex items-center justify-between">
+                <div>
+                  <div className="font-medium">{p.name}</div>
+                  <div className="text-sm opacity-70">{p.specs.surface}</div>
+                </div>
+                <div className="text-sm font-semibold">£{p.price}</div>
+              </div>
+            </Link>
+          ))}
+        </div>
+      </Section>
+    </>
   );
 }

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,0 +1,3 @@
+export function Section({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+  return <section className={`mx-auto max-w-6xl px-4 py-16 ${className}`}>{children}</section>;
+}

--- a/data/products.json
+++ b/data/products.json
@@ -1,0 +1,26 @@
+[
+  {
+    "id": 1,
+    "slug": "precision-pro",
+    "name": "Precision Pro",
+    "price": 199,
+    "images": ["/logo.svg"],
+    "specs": { "surface": "Carbon Fiber" }
+  },
+  {
+    "id": 2,
+    "slug": "control-x",
+    "name": "Control X",
+    "price": 179,
+    "images": ["/logo.svg"],
+    "specs": { "surface": "Fiberglass" }
+  },
+  {
+    "id": 3,
+    "slug": "power-lite",
+    "name": "Power Lite",
+    "price": 149,
+    "images": ["/logo.svg"],
+    "specs": { "surface": "Hybrid" }
+  }
+]

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,0 +1,3 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
+  <text x="0" y="15" font-size="15" font-family="sans-serif">Club Fore</text>
+</svg>


### PR DESCRIPTION
## Summary
- build Section component for consistent layout spacing
- implement hero, features, and product highlight sections on home page
- add sample product data and logo asset

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c2e9b5403c8332bc6deb1c05b82471