### PR TITLE
style(theme): switch to black background with white panel UI + polish

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,9 @@
+import { Section } from "@/components/Section";
+
 export default function AboutPage() {
   return (
-    <div className="p-4">
-      About page coming soon.
-    </div>
+    <Section>
+      <p>About page coming soon.</p>
+    </Section>
   );
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,7 +1,9 @@
+import { Section } from "@/components/Section";
+
 export default function ContactPage() {
   return (
-    <div className="p-4">
-      Contact page coming soon.
-    </div>
+    <Section>
+      <p>Contact page coming soon.</p>
+    </Section>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -3,7 +3,21 @@
 @tailwind utilities;
 
 :root { color-scheme: light dark; }
-html, body { height: 100%; background: #fff; color: #000; }
+html, body {
+  height: 100%;
+  background: #000;
+  color: #fff;
+}
+
+a {
+  text-decoration: underline;
+  text-underline-offset: 2px;
+}
+
+a:hover {
+  opacity: 0.8;
+}
+
 * { outline-offset: 2px; }
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; transition: none !important; scroll-behavior: auto !important; }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -15,11 +15,18 @@ export default function Home() {
               Sleek padel gear engineered for control and built to last.
             </p>
             <div className="mt-8 flex gap-3">
-              <Link className="px-5 py-3 bg-black text-white rounded-2xl border" href="/products">Shop Paddles</Link>
-              <Link className="px-5 py-3 border rounded-2xl" href="/contact">Contact</Link>
+              <Link
+                className="px-5 py-3 rounded-2xl bg-white text-black border"
+                href="/products"
+              >
+                Shop Paddles
+              </Link>
+              <Link className="px-5 py-3 rounded-2xl border text-black" href="/contact">
+                Contact
+              </Link>
             </div>
           </div>
-          <div className="border rounded-2xl p-6 bg-white">
+          <div className="rounded-2xl border border-black/10 p-6 bg-white shadow">
             <Image src="/logo.svg" width={800} height={400} alt="Club Fore wordmark" className="w-full h-auto" />
           </div>
         </div>
@@ -32,7 +39,10 @@ export default function Home() {
             { title: "Vibration dampening", text: "Composite layups reduce arm fatigue." },
             { title: "Sustainable build", text: "Durable materials for a longer lifecycle." }
           ].map((f) => (
-            <div key={f.title} className="border rounded-2xl p-6">
+            <div
+              key={f.title}
+              className="rounded-2xl p-6 bg-white border border-black/10 shadow-sm"
+            >
               <h3 className="font-medium">{f.title}</h3>
               <p className="opacity-70 text-sm mt-2">{f.text}</p>
             </div>
@@ -43,18 +53,32 @@ export default function Home() {
       <Section>
         <div className="flex items-baseline justify-between mb-6">
           <h2 className="text-2xl font-semibold">Highlights</h2>
-          <Link href="/products" className="text-sm underline">View all</Link>
+          <Link href="/products" className="text-sm underline">
+            View all
+          </Link>
         </div>
         <div className="grid md:grid-cols-3 gap-6">
           {highlights.map((p) => (
-            <Link key={p.id} href={`/products/${p.slug}`} className="border rounded-2xl p-4 hover:opacity-80">
-              <Image src={p.images[0]} alt={p.name} width={600} height={400} className="w-full h-auto rounded-xl border" />
+            <Link
+              key={p.id}
+              href={`/products/${p.slug}`}
+              className="rounded-2xl p-4 bg-white border border-black/10 shadow-sm transition motion-safe:hover:-translate-y-1 hover:shadow-md"
+            >
+              <div className="aspect-[4/3] w-full overflow-hidden rounded-xl border border-black/10">
+                <Image
+                  src={p.images[0]}
+                  alt={p.name}
+                  width={600}
+                  height={400}
+                  className="h-full w-full object-cover"
+                />
+              </div>
               <div className="mt-3 flex items-center justify-between">
                 <div>
                   <div className="font-medium">{p.name}</div>
                   <div className="text-sm opacity-70">{p.specs.surface}</div>
                 </div>
-                <div className="text-sm font-semibold">£{p.price}</div>
+                <div className="text-sm font-semibold text-right">£{p.price}</div>
               </div>
             </Link>
           ))}

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -1,4 +1,5 @@
 import { notFound } from "next/navigation";
+import { Section } from "@/components/Section";
 
 interface ProductPageProps {
   params: { slug: string };
@@ -10,8 +11,8 @@ export default function ProductPage({ params }: ProductPageProps) {
   }
 
   return (
-    <div className="p-4">
+    <Section>
       Product <strong>{params.slug}</strong> coming soon.
-    </div>
+    </Section>
   );
 }

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,7 +1,9 @@
+import { Section } from "@/components/Section";
+
 export default function ProductsPage() {
   return (
-    <div className="p-4">
-      Products page coming soon.
-    </div>
+    <Section>
+      <p>Products page coming soon.</p>
+    </Section>
   );
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,8 +14,8 @@ export function Footer() {
     if (res.ok) setSent(true);
   }
   return (
-    <footer className="border-t">
-      <div className="mx-auto max-w-6xl px-4 py-10 grid gap-6 md:grid-cols-2 items-center">
+    <footer className="border-t border-white/10 bg-black">
+      <div className="mx-auto max-w-6xl px-4 py-10 grid gap-6 md:grid-cols-2 items-center text-white">
         <div>
           <div className="font-semibold">Club Fore</div>
           <p className="text-sm opacity-70">Precision meets power.</p>
@@ -28,11 +28,21 @@ export function Footer() {
             placeholder="you@example.com"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="flex-1 border rounded-2xl px-3 py-2"
+            className="flex-1 border rounded-2xl px-3 py-2 bg-white text-black"
           />
-          <button className="border rounded-2xl px-4 py-2 bg-black text-white">Subscribe</button>
+          <button className="rounded-2xl px-4 py-2 bg-white text-black border">
+            Subscribe
+          </button>
         </form>
         {sent && <p className="text-sm">Thanks — you’re on the list.</p>}
+        <div className="text-sm mt-4 flex gap-4">
+          <a href="/privacy" className="hover:opacity-80">
+            Privacy
+          </a>
+          <a href="/terms" className="hover:opacity-80">
+            Terms
+          </a>
+        </div>
       </div>
     </footer>
   );

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,28 +5,34 @@ import { useState } from "react";
 export function Navbar() {
   const [open, setOpen] = useState(false);
   return (
-    <header className="sticky top-0 z-50 bg-white/90 border-b backdrop-blur">
-      <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
+    <header className="sticky top-0 z-50 bg-black/60 border-b border-white/10 backdrop-blur">
+      <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between text-white">
         <Link href="/" className="font-semibold tracking-widest text-xl">CLUB FORE</Link>
         <nav className="hidden md:flex gap-6 text-sm">
-          <Link href="/products" className="hover:opacity-70">Products</Link>
-          <Link href="/about" className="hover:opacity-70">About</Link>
-          <Link href="/contact" className="hover:opacity-70">Contact</Link>
+          <Link href="/products" className="hover:opacity-80">Products</Link>
+          <Link href="/about" className="hover:opacity-80">About</Link>
+          <Link href="/contact" className="hover:opacity-80">Contact</Link>
         </nav>
         <button
           aria-label="Menu"
-          className="md:hidden p-2 border rounded"
+          className="md:hidden p-2 border border-white/20 rounded"
           onClick={() => setOpen(!open)}
         >
           ☰
         </button>
       </div>
       {open && (
-        <div className="md:hidden border-t">
+        <div className="md:hidden border-t border-white/10 bg-black text-white">
           <div className="mx-auto max-w-6xl px-4 py-2 flex flex-col gap-2">
-            <Link href="/products" onClick={() => setOpen(false)}>Products</Link>
-            <Link href="/about" onClick={() => setOpen(false)}>About</Link>
-            <Link href="/contact" onClick={() => setOpen(false)}>Contact</Link>
+            <Link href="/products" className="hover:opacity-80" onClick={() => setOpen(false)}>
+              Products
+            </Link>
+            <Link href="/about" className="hover:opacity-80" onClick={() => setOpen(false)}>
+              About
+            </Link>
+            <Link href="/contact" className="hover:opacity-80" onClick={() => setOpen(false)}>
+              Contact
+            </Link>
           </div>
         </div>
       )}

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,3 +1,9 @@
 export function Section({ children, className = "" }: { children: React.ReactNode; className?: string }) {
-  return <section className={`mx-auto max-w-6xl px-4 py-16 ${className}`}>{children}</section>;
+  return (
+    <section
+      className={`mx-auto max-w-6xl px-4 py-16 rounded-2xl bg-white text-black border border-black/10 shadow ${className}`}
+    >
+      {children}
+    </section>
+  );
 }


### PR DESCRIPTION
## Summary
- switch global theme to black with white text and links
- add reusable white panel section component for content
- restyle navigation, footer, and home panels for dark theme polish

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c3162a0a3c83329491cb242df28674