### PR TITLE
style(ui): ultra-minimal true-dark design (no white cards)

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -1,7 +1,5 @@
+import { Section } from "@/components/Section";
+
 export default function AboutPage() {
-  return (
-    <div className="p-4">
-      About page coming soon.
-    </div>
-  );
+  return <Section className="max-w-2xl">About page coming soon.</Section>;
 }

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -1,7 +1,5 @@
+import { Section } from "@/components/Section";
+
 export default function ContactPage() {
-  return (
-    <div className="p-4">
-      Contact page coming soon.
-    </div>
-  );
+  return <Section className="max-w-2xl">Contact page coming soon.</Section>;
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -2,9 +2,10 @@
 @tailwind components;
 @tailwind utilities;
 
-:root { color-scheme: light dark; }
-html, body { height: 100%; background: #fff; color: #000; }
-* { outline-offset: 2px; }
+:root { color-scheme: dark; }
+html, body { height: 100%; background: #000; color: #fff; }
+a { text-underline-offset: 4px; }
+*:focus-visible { outline: 2px solid rgba(255, 255, 255, 0.6); outline-offset: 2px; }
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; transition: none !important; scroll-behavior: auto !important; }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -10,17 +10,17 @@ export default function Home() {
       <Section className="py-24">
         <div className="grid md:grid-cols-2 gap-8 items-center">
           <div>
-            <h1 className="text-4xl md:text-5xl font-semibold tracking-tight">Precision meets power.</h1>
+            <h1 className="text-5xl md:text-6xl font-semibold tracking-tight">Precision meets power.</h1>
             <p className="mt-4 text-lg opacity-80">
               Sleek padel gear engineered for control and built to last.
             </p>
             <div className="mt-8 flex gap-3">
-              <Link className="px-5 py-3 bg-black text-white rounded-2xl border" href="/products">Shop Paddles</Link>
-              <Link className="px-5 py-3 border rounded-2xl" href="/contact">Contact</Link>
+              <Link className="px-5 py-3 rounded-2xl bg-white text-black" href="/products">Shop Paddles</Link>
+              <Link className="px-5 py-3 rounded-2xl border border-white/30 text-white" href="/contact">Contact</Link>
             </div>
           </div>
-          <div className="border rounded-2xl p-6 bg-white">
-            <Image src="/logo.svg" width={800} height={400} alt="Club Fore wordmark" className="w-full h-auto" />
+          <div className="rounded-2xl bg-neutral-950 border border-white/10 p-6">
+            <Image src="/logo.svg" width={800} height={400} alt="Club Fore wordmark" className="w-full h-auto rounded-xl border border-white/10" />
           </div>
         </div>
       </Section>
@@ -32,9 +32,9 @@ export default function Home() {
             { title: "Vibration dampening", text: "Composite layups reduce arm fatigue." },
             { title: "Sustainable build", text: "Durable materials for a longer lifecycle." }
           ].map((f) => (
-            <div key={f.title} className="border rounded-2xl p-6">
+            <div key={f.title} className="rounded-2xl bg-neutral-950 border border-white/10 p-6">
               <h3 className="font-medium">{f.title}</h3>
-              <p className="opacity-70 text-sm mt-2">{f.text}</p>
+              <p className="opacity-80 text-sm mt-2">{f.text}</p>
             </div>
           ))}
         </div>
@@ -47,12 +47,22 @@ export default function Home() {
         </div>
         <div className="grid md:grid-cols-3 gap-6">
           {highlights.map((p) => (
-            <Link key={p.id} href={`/products/${p.slug}`} className="border rounded-2xl p-4 hover:opacity-80">
-              <Image src={p.images[0]} alt={p.name} width={600} height={400} className="w-full h-auto rounded-xl border" />
+            <Link
+              key={p.id}
+              href={`/products/${p.slug}`}
+              className="rounded-2xl bg-neutral-950 border border-white/10 p-4 hover:-translate-y-0.5 hover:ring-1 hover:ring-white/20 transition"
+            >
+              <Image
+                src={p.images[0]}
+                alt={p.name}
+                width={600}
+                height={400}
+                className="w-full h-auto rounded-xl border border-white/10"
+              />
               <div className="mt-3 flex items-center justify-between">
                 <div>
                   <div className="font-medium">{p.name}</div>
-                  <div className="text-sm opacity-70">{p.specs.surface}</div>
+                  <div className="text-sm opacity-80">{p.specs.surface}</div>
                 </div>
                 <div className="text-sm font-semibold">£{p.price}</div>
               </div>

--- a/app/products/[slug]/page.tsx
+++ b/app/products/[slug]/page.tsx
@@ -4,14 +4,16 @@ interface ProductPageProps {
   params: { slug: string };
 }
 
+import { Section } from "@/components/Section";
+
 export default function ProductPage({ params }: ProductPageProps) {
   if (!params.slug) {
     notFound();
   }
 
   return (
-    <div className="p-4">
+    <Section className="max-w-2xl">
       Product <strong>{params.slug}</strong> coming soon.
-    </div>
+    </Section>
   );
 }

--- a/app/products/page.tsx
+++ b/app/products/page.tsx
@@ -1,7 +1,5 @@
+import { Section } from "@/components/Section";
+
 export default function ProductsPage() {
-  return (
-    <div className="p-4">
-      Products page coming soon.
-    </div>
-  );
+  return <Section className="max-w-2xl">Products page coming soon.</Section>;
 }

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -14,11 +14,11 @@ export function Footer() {
     if (res.ok) setSent(true);
   }
   return (
-    <footer className="border-t">
+    <footer className="border-t border-white/10 bg-black/50">
       <div className="mx-auto max-w-6xl px-4 py-10 grid gap-6 md:grid-cols-2 items-center">
         <div>
           <div className="font-semibold">Club Fore</div>
-          <p className="text-sm opacity-70">Precision meets power.</p>
+          <p className="text-sm opacity-80">Precision meets power.</p>
         </div>
         <form onSubmit={submit} className="flex gap-2">
           <input
@@ -28,9 +28,9 @@ export function Footer() {
             placeholder="you@example.com"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="flex-1 border rounded-2xl px-3 py-2"
+            className="flex-1 rounded-2xl bg-neutral-950 border border-white/20 px-3 py-2 text-white placeholder-white/40"
           />
-          <button className="border rounded-2xl px-4 py-2 bg-black text-white">Subscribe</button>
+          <button className="px-4 py-2 rounded-2xl bg-white text-black">Subscribe</button>
         </form>
         {sent && <p className="text-sm">Thanks — you’re on the list.</p>}
       </div>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -5,28 +5,28 @@ import { useState } from "react";
 export function Navbar() {
   const [open, setOpen] = useState(false);
   return (
-    <header className="sticky top-0 z-50 bg-white/90 border-b backdrop-blur">
+    <header className="sticky top-0 z-50 bg-black/50 backdrop-blur border-b border-white/10">
       <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between">
-        <Link href="/" className="font-semibold tracking-widest text-xl">CLUB FORE</Link>
+        <Link href="/" className="font-semibold tracking-widest text-xl text-white">CLUB FORE</Link>
         <nav className="hidden md:flex gap-6 text-sm">
-          <Link href="/products" className="hover:opacity-70">Products</Link>
-          <Link href="/about" className="hover:opacity-70">About</Link>
-          <Link href="/contact" className="hover:opacity-70">Contact</Link>
+          <Link href="/products" className="hover:opacity-70 text-white">Products</Link>
+          <Link href="/about" className="hover:opacity-70 text-white">About</Link>
+          <Link href="/contact" className="hover:opacity-70 text-white">Contact</Link>
         </nav>
         <button
           aria-label="Menu"
-          className="md:hidden p-2 border rounded"
+          className="md:hidden p-2 border border-white/20 rounded text-white"
           onClick={() => setOpen(!open)}
         >
           ☰
         </button>
       </div>
       {open && (
-        <div className="md:hidden border-t">
+        <div className="md:hidden border-t border-white/10 bg-black/90">
           <div className="mx-auto max-w-6xl px-4 py-2 flex flex-col gap-2">
-            <Link href="/products" onClick={() => setOpen(false)}>Products</Link>
-            <Link href="/about" onClick={() => setOpen(false)}>About</Link>
-            <Link href="/contact" onClick={() => setOpen(false)}>Contact</Link>
+            <Link href="/products" className="text-white hover:opacity-70" onClick={() => setOpen(false)}>Products</Link>
+            <Link href="/about" className="text-white hover:opacity-70" onClick={() => setOpen(false)}>About</Link>
+            <Link href="/contact" className="text-white hover:opacity-70" onClick={() => setOpen(false)}>Contact</Link>
           </div>
         </div>
       )}

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,3 +1,19 @@
-export function Section({ children, className = "" }: { children: React.ReactNode; className?: string }) {
-  return <section className={`mx-auto max-w-6xl px-4 py-16 ${className}`}>{children}</section>;
+export function Section({
+  children,
+  className = "",
+  surface = false
+}: {
+  children: React.ReactNode;
+  className?: string;
+  surface?: boolean;
+}) {
+  return (
+    <section className={`mx-auto max-w-6xl px-4 py-16 ${className}`}>
+      {surface ? (
+        <div className="rounded-2xl bg-neutral-950 border border-white/10">{children}</div>
+      ) : (
+        children
+      )}
+    </section>
+  );
 }


### PR DESCRIPTION
## Summary
- switch site-wide to a true-dark palette with black background, white text and subtle focus ring
- add optional `surface` prop to `Section` and update Navbar/Footer for dark translucent chrome
- restyle hero, feature tiles and product highlights with onyx surfaces, white dividers and minimalist CTAs

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c31a8633b88332a183ddae8da487cd