### PR TITLE
fix: resolve merge conflicts and finalize true-dark pass

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,7 +2,7 @@ import { Section } from "@/components/Section";
 
 export default function AboutPage() {
   return (
-    <Section>
+    <Section className="max-w-2xl">
       <p>About page coming soon.</p>
     </Section>
   );

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,7 +2,7 @@ import { Section } from "@/components/Section";
 
 export default function ContactPage() {
   return (
-    <Section>
+    <Section className="max-w-2xl">
       <p>Contact page coming soon.</p>
     </Section>
   );

--- a/app/globals.css
+++ b/app/globals.css
@@ -10,6 +10,7 @@ html, body {
 }
 
 a {
+  color: #fff;
   text-decoration: underline;
   text-underline-offset: 2px;
 }
@@ -17,8 +18,10 @@ a {
 a:hover {
   opacity: 0.8;
 }
-
-* { outline-offset: 2px; }
+*:focus-visible {
+  outline: 2px solid #fff;
+  outline-offset: 2px;
+}
 @media (prefers-reduced-motion: reduce) {
   * { animation: none !important; transition: none !important; scroll-behavior: auto !important; }
 }

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -16,19 +16,26 @@ export default function Home() {
             </p>
             <div className="mt-8 flex gap-3">
               <Link
-                className="px-5 py-3 rounded-2xl bg-white text-black border"
+                className="px-5 py-3 rounded-2xl bg-white text-black hover:ring-2 hover:ring-white/20"
                 href="/products"
               >
                 Shop Paddles
               </Link>
-              <Link className="px-5 py-3 rounded-2xl border text-black" href="/contact">
+              <Link
+                className="px-5 py-3 rounded-2xl border border-white/30 text-white bg-transparent hover:ring-2 hover:ring-white/20"
+                href="/contact"
+              >
                 Contact
               </Link>
             </div>
           </div>
-          <div className="rounded-2xl border border-black/10 p-6 bg-white shadow">
-            <Image src="/logo.svg" width={800} height={400} alt="Club Fore wordmark" className="w-full h-auto" />
-          </div>
+          <Image
+            src="/logo.svg"
+            width={800}
+            height={400}
+            alt="Club Fore wordmark"
+            className="w-full h-auto rounded-2xl border border-white/10"
+          />
         </div>
       </Section>
 
@@ -41,7 +48,7 @@ export default function Home() {
           ].map((f) => (
             <div
               key={f.title}
-              className="rounded-2xl p-6 bg-white border border-black/10 shadow-sm"
+              className="rounded-2xl p-6 bg-neutral-950 border border-white/10"
             >
               <h3 className="font-medium">{f.title}</h3>
               <p className="opacity-70 text-sm mt-2">{f.text}</p>
@@ -62,9 +69,9 @@ export default function Home() {
             <Link
               key={p.id}
               href={`/products/${p.slug}`}
-              className="rounded-2xl p-4 bg-white border border-black/10 shadow-sm transition motion-safe:hover:-translate-y-1 hover:shadow-md"
+              className="rounded-2xl p-4 bg-neutral-950 border border-white/10 transition hover:ring-2 hover:ring-white/20"
             >
-              <div className="aspect-[4/3] w-full overflow-hidden rounded-xl border border-black/10">
+              <div className="aspect-[4/3] w-full overflow-hidden rounded-xl border border-white/10">
                 <Image
                   src={p.images[0]}
                   alt={p.name}

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -28,9 +28,9 @@ export function Footer() {
             placeholder="you@example.com"
             value={email}
             onChange={(e) => setEmail(e.target.value)}
-            className="flex-1 border rounded-2xl px-3 py-2 bg-white text-black"
+            className="flex-1 rounded-2xl px-3 py-2 bg-neutral-950 text-white border border-white/20 placeholder-white/40"
           />
-          <button className="rounded-2xl px-4 py-2 bg-white text-black border">
+          <button className="rounded-2xl px-5 py-3 bg-white text-black hover:ring-2 hover:ring-white/20">
             Subscribe
           </button>
         </form>

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -15,7 +15,7 @@ export function Navbar() {
         </nav>
         <button
           aria-label="Menu"
-          className="md:hidden p-2 border border-white/20 rounded"
+          className="md:hidden p-2 border border-white/30 rounded hover:ring-2 hover:ring-white/20"
           onClick={() => setOpen(!open)}
         >
           ☰

--- a/components/Section.tsx
+++ b/components/Section.tsx
@@ -1,9 +1,21 @@
-export function Section({ children, className = "" }: { children: React.ReactNode; className?: string }) {
+import React from "react";
+
+export function Section({
+  children,
+  className = "",
+  surface = false,
+}: {
+  children: React.ReactNode;
+  className?: string;
+  surface?: boolean;
+}) {
   return (
-    <section
-      className={`mx-auto max-w-6xl px-4 py-16 rounded-2xl bg-white text-black border border-black/10 shadow ${className}`}
-    >
-      {children}
+    <section className={`mx-auto max-w-6xl px-4 py-16 ${className}`}>
+      {surface ? (
+        <div className="rounded-2xl bg-neutral-950 border border-white/10">{children}</div>
+      ) : (
+        children
+      )}
     </section>
   );
 }


### PR DESCRIPTION
## Summary
- adopt true dark global theme with white text and focus styles
- simplify Section API and convert pages/components to dark surfaces
- update nav, footer, buttons and tiles for consistent dark UI

## Testing
- `npm run typecheck`
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c323538dc0833285490efcc813ab3e