### PR TITLE
feat(content): minimal front page + membership + shop + about for Club Fore

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,8 +2,17 @@ import { Section } from "@/components/Section";
 
 export default function AboutPage() {
   return (
-    <Section className="max-w-2xl">
-      <p>About page coming soon.</p>
+    <Section className="max-w-2xl py-24 space-y-8">
+      <h1 className="text-4xl font-bold">About Club Fore</h1>
+      <p>
+        We strip everything back to what matters: feel, balance, longevity.<br />
+        Quiet design. Clear intent.
+      </p>
+      <p>
+        Every product starts on court and ends in your hand.<br />
+        No extras. Only what works.
+      </p>
+      <p className="text-sm opacity-60">Designed in London. Played everywhere.</p>
     </Section>
   );
 }

--- a/app/globals.css
+++ b/app/globals.css
@@ -11,8 +11,7 @@ html, body {
 
 a {
   color: #fff;
-  text-decoration: underline;
-  text-underline-offset: 2px;
+  text-decoration: none;
 }
 
 a:hover {

--- a/app/membership/page.tsx
+++ b/app/membership/page.tsx
@@ -1,0 +1,27 @@
+import Link from "next/link";
+import { Section } from "@/components/Section";
+
+export default function MembershipPage() {
+  return (
+    <Section className="max-w-2xl py-24 space-y-8">
+      <h1 className="text-4xl font-bold">Membership at Club Fore</h1>
+      <p>A private network for players who value focus over noise.</p>
+      <div className="divide-y divide-white/10">
+        <div className="py-6">
+          <h2 className="font-semibold">Standard</h2>
+          <p className="opacity-80">Priority booking, member rates.</p>
+        </div>
+        <div className="py-6">
+          <h2 className="font-semibold">Premium</h2>
+          <p className="opacity-80">Extended access, guest passes, event invites.</p>
+        </div>
+        <div className="py-6">
+          <h2 className="font-semibold">Founders</h2>
+          <p className="opacity-80">Lifetime perks, limited availability.</p>
+        </div>
+      </div>
+      <p className="text-sm opacity-60">Spaces are limited. Applications reviewed weekly.</p>
+      <Link href="/contact" className="inline-block px-6 py-3 rounded-2xl bg-white text-black">Apply for Membership</Link>
+    </Section>
+  );
+}

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,96 +1,22 @@
 import Link from "next/link";
-import Image from "next/image";
 import { Section } from "@/components/Section";
-import products from "@/data/products.json";
 
 export default function Home() {
-  const highlights = products.slice(0, 3);
   return (
-    <>
-      <Section className="py-24">
-        <div className="grid md:grid-cols-2 gap-8 items-center">
-          <div>
-            <h1 className="text-4xl md:text-5xl font-semibold tracking-tight">Precision meets power.</h1>
-            <p className="mt-4 text-lg opacity-80">
-              Sleek padel gear engineered for control and built to last.
-            </p>
-            <div className="mt-8 flex gap-3">
-              <Link
-                className="px-5 py-3 rounded-2xl bg-white text-black hover:ring-2 hover:ring-white/20"
-                href="/products"
-              >
-                Shop Paddles
-              </Link>
-              <Link
-                className="px-5 py-3 rounded-2xl border border-white/30 text-white bg-transparent hover:ring-2 hover:ring-white/20"
-                href="/contact"
-              >
-                Contact
-              </Link>
-            </div>
-          </div>
-          <Image
-            src="/logo.svg"
-            width={800}
-            height={400}
-            alt="Club Fore wordmark"
-            className="w-full h-auto rounded-2xl border border-white/10"
-          />
-        </div>
-      </Section>
-
-      <Section>
-        <div className="grid md:grid-cols-3 gap-6">
-          {[
-            { title: "Control", text: "Balanced frames for surgical placement." },
-            { title: "Vibration dampening", text: "Composite layups reduce arm fatigue." },
-            { title: "Sustainable build", text: "Durable materials for a longer lifecycle." }
-          ].map((f) => (
-            <div
-              key={f.title}
-              className="rounded-2xl p-6 bg-neutral-950 border border-white/10"
-            >
-              <h3 className="font-medium">{f.title}</h3>
-              <p className="opacity-70 text-sm mt-2">{f.text}</p>
-            </div>
-          ))}
-        </div>
-      </Section>
-
-      <Section>
-        <div className="flex items-baseline justify-between mb-6">
-          <h2 className="text-2xl font-semibold">Highlights</h2>
-          <Link href="/products" className="text-sm underline">
-            View all
-          </Link>
-        </div>
-        <div className="grid md:grid-cols-3 gap-6">
-          {highlights.map((p) => (
-            <Link
-              key={p.id}
-              href={`/products/${p.slug}`}
-              className="rounded-2xl p-4 bg-neutral-950 border border-white/10 transition hover:ring-2 hover:ring-white/20"
-            >
-              <div className="aspect-[4/3] w-full overflow-hidden rounded-xl border border-white/10">
-                <Image
-                  src={p.images[0]}
-                  alt={p.name}
-                  width={600}
-                  height={400}
-                  className="h-full w-full object-cover"
-                />
-              </div>
-              <div className="mt-3 flex items-center justify-between">
-                <div>
-                  <div className="font-medium">{p.name}</div>
-                  <div className="text-sm opacity-70">{p.specs.surface}</div>
-                </div>
-                <div className="text-sm font-semibold text-right">£{p.price}</div>
-              </div>
-            </Link>
-          ))}
-        </div>
-      </Section>
-    </>
+    <Section className="min-h-[80vh] flex flex-col items-center justify-center text-center space-y-8">
+      <h1 className="text-6xl md:text-8xl font-bold">CLUB FORE</h1>
+      <p className="text-lg opacity-80">Precision. Power. Minimalism.</p>
+      <div className="flex gap-4">
+        <Link href="/membership" className="px-6 py-3 rounded-2xl bg-white text-black">Membership</Link>
+        <Link href="/shop" className="px-6 py-3 rounded-2xl border border-white bg-transparent">Shop</Link>
+      </div>
+      <div className="mt-16 flex items-center gap-2 text-xs opacity-50">
+        <span>Control</span>
+        <span>·</span>
+        <span>Balance</span>
+        <span>·</span>
+        <span>Longevity</span>
+      </div>
+    </Section>
   );
 }

--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -1,0 +1,21 @@
+import Link from "next/link";
+import { Section } from "@/components/Section";
+
+export default function ShopPage() {
+  return (
+    <Section className="max-w-3xl py-24 space-y-8">
+      <h1 className="text-4xl font-bold">Club Fore Apparel</h1>
+      <p>Monochrome essentials for on and off court.</p>
+      <div className="grid grid-cols-1 md:grid-cols-2 gap-x-8 gap-y-4">
+        <div>CF Logo Tee — Black / White</div>
+        <div>Performance Hoodie — Black</div>
+        <div>Court Cap — Black</div>
+        <div>Minimal Tote — Natural / Black</div>
+        <div>Warm-Up Crew — Black</div>
+        <div>Training Shorts — Black</div>
+      </div>
+      <p className="text-sm opacity-60">Clean lines. No loud logos. Built to last.</p>
+      <Link href="/products" className="inline-block px-6 py-3 rounded-2xl bg-white text-black">Enter Shop</Link>
+    </Section>
+  );
+}

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -9,9 +9,9 @@ export function Navbar() {
       <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between text-white">
         <Link href="/" className="font-semibold tracking-widest text-xl">CLUB FORE</Link>
         <nav className="hidden md:flex gap-6 text-sm">
-          <Link href="/products" className="hover:opacity-80">Products</Link>
+          <Link href="/membership" className="hover:opacity-80">Membership</Link>
+          <Link href="/shop" className="hover:opacity-80">Shop</Link>
           <Link href="/about" className="hover:opacity-80">About</Link>
-          <Link href="/contact" className="hover:opacity-80">Contact</Link>
         </nav>
         <button
           aria-label="Menu"
@@ -24,14 +24,14 @@ export function Navbar() {
       {open && (
         <div className="md:hidden border-t border-white/10 bg-black text-white">
           <div className="mx-auto max-w-6xl px-4 py-2 flex flex-col gap-2">
-            <Link href="/products" className="hover:opacity-80" onClick={() => setOpen(false)}>
-              Products
+            <Link href="/membership" className="hover:opacity-80" onClick={() => setOpen(false)}>
+              Membership
+            </Link>
+            <Link href="/shop" className="hover:opacity-80" onClick={() => setOpen(false)}>
+              Shop
             </Link>
             <Link href="/about" className="hover:opacity-80" onClick={() => setOpen(false)}>
               About
-            </Link>
-            <Link href="/contact" className="hover:opacity-80" onClick={() => setOpen(false)}>
-              Contact
             </Link>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- simplify homepage to hero-only branding with membership and shop CTAs
- add minimal Membership, Shop, and About pages matching Club Fore voice
- update navigation and remove link underlines for monochrome look

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c326f5ff588332ab16fb54f7c7a3de