### PR TITLE
feat: add scroll-driven hero (logo → wireframe court → content) with dynamic OG, no binaries

### DIFF
--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -11,15 +11,17 @@ export default function OpengraphImage() {
           height: "100%",
           width: "100%",
           display: "flex",
+          flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
           background: "#000",
           color: "#fff",
-          fontSize: 128,
           fontWeight: 700,
+          gap: 40,
         }}
       >
-        CLUB FORE
+        <div style={{ fontSize: 128 }}>CLUB FORE</div>
+        <div style={{ fontSize: 48, fontWeight: 400 }}>Precision. Power. Minimalism.</div>
       </div>
     ),
     size

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,7 @@
 import Link from "next/link";
 import type { Metadata } from "next";
+import { motion, useScroll, useTransform } from "framer-motion";
+import { useRef } from "react";
 
 export const metadata: Metadata = {
   description: "Precision. Power. Minimalism.",
@@ -8,12 +10,97 @@ export const metadata: Metadata = {
 };
 
 export default function Home() {
+  const ref = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ["start start", "end start"] });
+
+  const logoScale = useTransform(scrollYProgress, [0, 0.3], [1.2, 0.8]);
+  const logoOpacity = useTransform(scrollYProgress, [0, 0.3], [1, 0]);
+  const logoY = useTransform(scrollYProgress, [0, 0.3], ["0%", "-40%"]);
+
+  const courtOpacity = useTransform(scrollYProgress, [0.25, 0.6], [0, 1]);
+  const courtScale = useTransform(scrollYProgress, [0.3, 0.8], [0.9, 1]);
+  const courtY = useTransform(scrollYProgress, [0.3, 0.8], ["20%", "0%"]);
+  const dash = useTransform(scrollYProgress, [0.3, 0.8], [1, 0]);
+
+  const imageOpacity = useTransform(scrollYProgress, [0.75, 1], [0, 1]);
+
   return (
-    <div className="min-h-[88vh] md:min-h-screen grid place-items-center px-4">
-      <div className="text-center space-y-8 md:space-y-10">
-        <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">CLUB FORE</h1>
-        <p className="text-sm md:text-base text-white/70">Precision. Power. Minimalism.</p>
-        <div className="flex justify-center gap-4">
+    <main ref={ref} className="bg-black text-white">
+      <div className="relative h-[200vh]">
+        <div className="sticky top-0 h-screen flex items-center justify-center overflow-hidden">
+          <motion.h1
+            style={{ scale: logoScale, opacity: logoOpacity, y: logoY }}
+            className="text-6xl md:text-7xl tracking-tight"
+          >
+            CLUB FORE
+          </motion.h1>
+
+          <motion.div
+            style={{ opacity: courtOpacity, scale: courtScale, y: courtY }}
+            className="absolute inset-0 flex items-center justify-center"
+          >
+            <motion.svg
+              viewBox="0 0 1000 640"
+              className="w-full max-w-5xl text-white"
+              style={{ "--dash": dash } as any}
+            >
+              <rect
+                x="80"
+                y="60"
+                width="840"
+                height="520"
+                stroke="currentColor"
+                strokeWidth="2"
+                fill="none"
+                className="[stroke-dasharray:1600] [stroke-dashoffset:calc(1600*var(--dash))]"
+              />
+              <line
+                x1="500"
+                y1="60"
+                x2="500"
+                y2="580"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="[stroke-dasharray:1040] [stroke-dashoffset:calc(1040*var(--dash))]"
+              />
+              <line
+                x1="80"
+                y1="320"
+                x2="920"
+                y2="320"
+                stroke="currentColor"
+                strokeWidth="2"
+                className="[stroke-dasharray:840] [stroke-dashoffset:calc(840*var(--dash))]"
+              />
+            </motion.svg>
+            <div
+              className="absolute inset-0 -z-10"
+              style={{
+                backgroundImage:
+                  "radial-gradient(circle at center, rgba(255,255,255,0.08), transparent 70%)," +
+                  "repeating-linear-gradient(rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)," +
+                  "repeating-linear-gradient(90deg, rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)"
+              }}
+            />
+          </motion.div>
+
+          <motion.div
+            style={{
+              opacity: imageOpacity,
+              backgroundImage:
+                "url(https://images.unsplash.com/photo-1555169062-013468b477d0?auto=format&fit=crop&w=1200&q=80)"
+            }}
+            className="absolute inset-0 bg-center bg-cover"
+          />
+        </div>
+      </div>
+
+      <section className="px-6 md:px-10 py-24 max-w-[72ch] mx-auto space-y-8">
+        <h2 className="text-3xl md:text-5xl font-semibold tracking-tight">Precision. Power. Minimalism.</h2>
+        <p className="text-white/70 leading-relaxed">
+          A club experience engineered for focus. Membership is limited.
+        </p>
+        <div className="flex gap-4">
           <Link
             href="/membership"
             className="inline-flex items-center rounded-2xl bg-white text-black px-6 py-3 font-medium hover:opacity-90 focus:outline-white/60 transition-transform duration-150 will-change-transform hover:-translate-y-0.5 hover:ring-1 hover:ring-white/20"
@@ -27,14 +114,8 @@ export default function Home() {
             Shop
           </Link>
         </div>
-        <div className="flex items-center justify-center gap-2 text-xs text-white/50 tracking-wide">
-          <span>Control</span>
-          <span>·</span>
-          <span>Balance</span>
-          <span>·</span>
-          <span>Longevity</span>
-        </div>
-      </div>
-    </div>
+      </section>
+    </main>
   );
 }
+

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -11,15 +11,17 @@ export default function TwitterImage() {
           height: "100%",
           width: "100%",
           display: "flex",
+          flexDirection: "column",
           alignItems: "center",
           justifyContent: "center",
           background: "#000",
           color: "#fff",
-          fontSize: 128,
           fontWeight: 700,
+          gap: 40,
         }}
       >
-        CLUB FORE
+        <div style={{ fontSize: 128 }}>CLUB FORE</div>
+        <div style={{ fontSize: 48, fontWeight: 400 }}>Precision. Power. Minimalism.</div>
       </div>
     ),
     size

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "firebase-admin": "12.6.0",
+        "framer-motion": "^10.16.3",
         "next": "14.2.5",
         "react": "18.3.1",
         "react-dom": "18.3.1",
@@ -74,6 +75,23 @@
       "dependencies": {
         "tslib": "^2.4.0"
       }
+    },
+    "node_modules/@emotion/is-prop-valid": {
+      "version": "0.8.8",
+      "resolved": "https://registry.npmjs.org/@emotion/is-prop-valid/-/is-prop-valid-0.8.8.tgz",
+      "integrity": "sha512-u5WtneEAr5IDG2Wv65yhunPSMLIpuKsbuOktRojfrEiEvRyC85LgPMZI63cr7NUqT8ZIGdSVg8ZKGxIug4lXcA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emotion/memoize": "0.7.4"
+      }
+    },
+    "node_modules/@emotion/memoize": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+      "integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==",
+      "license": "MIT",
+      "optional": true
     },
     "node_modules/@eslint-community/eslint-utils": {
       "version": "4.9.0",
@@ -3502,6 +3520,30 @@
       "funding": {
         "type": "patreon",
         "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/framer-motion": {
+      "version": "10.16.3",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-10.16.3.tgz",
+      "integrity": "sha512-1OMs6wY964hX8YjiCeYQlgrZDbkKvZztnynTUgUZjdzq2au6PZUsodmUY6GAudUgImrWqTrtpSwMbi1ETmIx4A==",
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.0"
+      },
+      "optionalDependencies": {
+        "@emotion/is-prop-valid": "^0.8.2"
+      },
+      "peerDependencies": {
+        "react": "^18.0.0",
+        "react-dom": "^18.0.0"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "test": "echo \"(no tests yet)\" && exit 0"
   },
   "dependencies": {
+    "firebase-admin": "12.6.0",
+    "framer-motion": "^10.16.3",
     "next": "14.2.5",
     "react": "18.3.1",
     "react-dom": "18.3.1",
-    "zod": "3.23.8",
     "react-hook-form": "7.53.0",
-    "firebase-admin": "12.6.0"
+    "zod": "3.23.8"
   },
   "devDependencies": {
     "@types/node": "20.11.30",
@@ -26,8 +27,8 @@
     "eslint": "8.57.0",
     "eslint-config-next": "14.2.5",
     "postcss": "8.4.38",
+    "prettier": "3.3.3",
     "tailwindcss": "3.4.10",
-    "typescript": "5.4.5",
-    "prettier": "3.3.3"
+    "typescript": "5.4.5"
   }
 }


### PR DESCRIPTION
## Summary
- implement scroll-driven hero with logo shrink/fade into animated wireframe court and content reveal
- add optional background image fade and digital grid styling
- create dynamic Open Graph & Twitter images without binary assets

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c33fd8116c8332a1fc0be50af499a7