### PR TITLE
feat: add scroll-driven hero and dynamic OG

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function AboutPage() {
   return (
-    <div className="max-w-2xl mx-auto px-4 py-24 space-y-6">
+    <div id="main" className="max-w-2xl mx-auto px-4 py-24 space-y-6">
       <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">About Club Fore</h1>
       <div className="max-w-[72ch] space-y-6 md:space-y-8">
         <p>We strip everything back to what matters: feel, balance, longevity.</p>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -9,7 +9,7 @@ export const metadata: Metadata = {
 
 export default function ContactPage() {
   return (
-    <div className="max-w-2xl mx-auto px-4 py-24 space-y-6">
+    <div id="main" className="max-w-2xl mx-auto px-4 py-24 space-y-6">
       <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">Contact</h1>
       <div className="max-w-[72ch] space-y-6 md:space-y-8">
         <p>Contact page coming soon.</p>

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -21,7 +21,7 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
           Skip to content
         </a>
         <Navbar />
-        <main id="main" className="flex-1">
+        <main className="flex-1">
           {children}
         </main>
         <Footer />

--- a/app/membership/page.tsx
+++ b/app/membership/page.tsx
@@ -11,7 +11,7 @@ export const metadata: Metadata = {
 
 export default function MembershipPage() {
   return (
-    <div className="max-w-4xl mx-auto px-4 py-24 space-y-8">
+    <div id="main" className="max-w-4xl mx-auto px-4 py-24 space-y-8">
       <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">Membership at Club Fore</h1>
       <div className="max-w-[72ch] space-y-6 md:space-y-8">
         <p>A private network for players who value focus over noise.</p>

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from "next/og";
 
+export const runtime = "edge";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,7 +1,6 @@
 import Link from "next/link";
 import type { Metadata } from "next";
-import { motion, useScroll, useTransform } from "framer-motion";
-import { useRef } from "react";
+import Hero from "@/components/Hero";
 
 export const metadata: Metadata = {
   description: "Precision. Power. Minimalism.",
@@ -10,92 +9,10 @@ export const metadata: Metadata = {
 };
 
 export default function Home() {
-  const ref = useRef<HTMLDivElement>(null);
-  const { scrollYProgress } = useScroll({ target: ref, offset: ["start start", "end start"] });
-
-  const logoScale = useTransform(scrollYProgress, [0, 0.3], [1.2, 0.8]);
-  const logoOpacity = useTransform(scrollYProgress, [0, 0.3], [1, 0]);
-  const logoY = useTransform(scrollYProgress, [0, 0.3], ["0%", "-40%"]);
-
-  const courtOpacity = useTransform(scrollYProgress, [0.25, 0.6], [0, 1]);
-  const courtScale = useTransform(scrollYProgress, [0.3, 0.8], [0.9, 1]);
-  const courtY = useTransform(scrollYProgress, [0.3, 0.8], ["20%", "0%"]);
-  const dash = useTransform(scrollYProgress, [0.3, 0.8], [1, 0]);
-
-  const imageOpacity = useTransform(scrollYProgress, [0.75, 1], [0, 1]);
-
   return (
-    <main ref={ref} className="bg-black text-white">
-      <div className="relative h-[200vh]">
-        <div className="sticky top-0 h-screen flex items-center justify-center overflow-hidden">
-          <motion.h1
-            style={{ scale: logoScale, opacity: logoOpacity, y: logoY }}
-            className="text-6xl md:text-7xl tracking-tight"
-          >
-            CLUB FORE
-          </motion.h1>
-
-          <motion.div
-            style={{ opacity: courtOpacity, scale: courtScale, y: courtY }}
-            className="absolute inset-0 flex items-center justify-center"
-          >
-            <motion.svg
-              viewBox="0 0 1000 640"
-              className="w-full max-w-5xl text-white"
-              style={{ "--dash": dash } as any}
-            >
-              <rect
-                x="80"
-                y="60"
-                width="840"
-                height="520"
-                stroke="currentColor"
-                strokeWidth="2"
-                fill="none"
-                className="[stroke-dasharray:1600] [stroke-dashoffset:calc(1600*var(--dash))]"
-              />
-              <line
-                x1="500"
-                y1="60"
-                x2="500"
-                y2="580"
-                stroke="currentColor"
-                strokeWidth="2"
-                className="[stroke-dasharray:1040] [stroke-dashoffset:calc(1040*var(--dash))]"
-              />
-              <line
-                x1="80"
-                y1="320"
-                x2="920"
-                y2="320"
-                stroke="currentColor"
-                strokeWidth="2"
-                className="[stroke-dasharray:840] [stroke-dashoffset:calc(840*var(--dash))]"
-              />
-            </motion.svg>
-            <div
-              className="absolute inset-0 -z-10"
-              style={{
-                backgroundImage:
-                  "radial-gradient(circle at center, rgba(255,255,255,0.08), transparent 70%)," +
-                  "repeating-linear-gradient(rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)," +
-                  "repeating-linear-gradient(90deg, rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)"
-              }}
-            />
-          </motion.div>
-
-          <motion.div
-            style={{
-              opacity: imageOpacity,
-              backgroundImage:
-                "url(https://images.unsplash.com/photo-1555169062-013468b477d0?auto=format&fit=crop&w=1200&q=80)"
-            }}
-            className="absolute inset-0 bg-center bg-cover"
-          />
-        </div>
-      </div>
-
-      <section className="px-6 md:px-10 py-24 max-w-[72ch] mx-auto space-y-8">
+    <>
+      <Hero />
+      <section id="main" className="px-6 md:px-10 py-24 max-w-[72ch] mx-auto space-y-8">
         <h2 className="text-3xl md:text-5xl font-semibold tracking-tight">Precision. Power. Minimalism.</h2>
         <p className="text-white/70 leading-relaxed">
           A club experience engineered for focus. Membership is limited.
@@ -115,7 +32,7 @@ export default function Home() {
           </Link>
         </div>
       </section>
-    </main>
+    </>
   );
 }
 

--- a/app/shop/page.tsx
+++ b/app/shop/page.tsx
@@ -10,7 +10,7 @@ export const metadata: Metadata = {
 
 export default function ShopPage() {
   return (
-    <div className="max-w-6xl mx-auto px-4 py-24 space-y-8">
+    <div id="main" className="max-w-6xl mx-auto px-4 py-24 space-y-8">
       <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">Shop</h1>
       <div className="max-w-[72ch] space-y-6 md:space-y-8">
         <p>Monochrome essentials for on and off court.</p>

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -1,5 +1,6 @@
 import { ImageResponse } from "next/og";
 
+export const runtime = "edge";
 export const size = { width: 1200, height: 630 };
 export const contentType = "image/png";
 

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import { useRef } from "react";
+import { motion, useScroll, useTransform, MotionValue } from "framer-motion";
+
+export default function Hero() {
+  const ref = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ["start start", "end start"] });
+
+  const logoScale = useTransform(scrollYProgress, [0, 0.3], [1.2, 0.8]);
+  const logoOpacity = useTransform(scrollYProgress, [0, 0.3], [1, 0]);
+  const logoY = useTransform(scrollYProgress, [0, 0.3], ["0%", "-40%"]);
+
+  const courtOpacity = useTransform(scrollYProgress, [0.25, 0.6], [0, 1]);
+  const courtScale = useTransform(scrollYProgress, [0.3, 0.8], [0.9, 1]);
+  const courtY = useTransform(scrollYProgress, [0.3, 0.8], ["20%", "0%"]);
+  const dash = useTransform(scrollYProgress, [0.3, 0.8], [1, 0]);
+
+  const imageOpacity = useTransform(scrollYProgress, [0.75, 1], [0, 1]);
+
+  return (
+    <section ref={ref} className="relative h-[200vh]">
+      <div className="sticky top-0 h-screen flex items-center justify-center overflow-hidden">
+        <motion.h1
+          style={{ scale: logoScale, opacity: logoOpacity, y: logoY }}
+          className="text-6xl md:text-7xl tracking-tight"
+        >
+          CLUB FORE
+        </motion.h1>
+
+        <motion.div
+          style={{ opacity: courtOpacity, scale: courtScale, y: courtY }}
+          className="absolute inset-0 flex items-center justify-center"
+        >
+          <WireframeCourt progress={dash} />
+          <div
+            className="absolute inset-0 -z-10"
+            style={{
+              backgroundImage:
+                "radial-gradient(circle at center, rgba(255,255,255,0.08), transparent 70%)," +
+                "repeating-linear-gradient(rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)," +
+                "repeating-linear-gradient(90deg, rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)",
+            }}
+          />
+        </motion.div>
+
+        <motion.div
+          style={{
+            opacity: imageOpacity,
+            backgroundImage:
+              "url(https://images.unsplash.com/photo-1555169062-013468b477d0?auto=format&fit=crop&w=1200&q=80)",
+          }}
+          className="absolute inset-0 bg-center bg-cover"
+        />
+      </div>
+    </section>
+  );
+}
+
+function WireframeCourt({ progress }: { progress: MotionValue<number> }) {
+  return (
+    <motion.svg
+      viewBox="0 0 1000 640"
+      className="w-full max-w-5xl text-white"
+      style={{ "--dash": progress } as any}
+    >
+      <rect
+        x="80"
+        y="60"
+        width="840"
+        height="520"
+        stroke="currentColor"
+        strokeWidth="2"
+        fill="none"
+        className="[stroke-dasharray:1600] [stroke-dashoffset:calc(1600*var(--dash))]"
+      />
+      <line
+        x1="500"
+        y1="60"
+        x2="500"
+        y2="580"
+        stroke="currentColor"
+        strokeWidth="2"
+        className="[stroke-dasharray:1040] [stroke-dashoffset:calc(1040*var(--dash))]"
+      />
+      <line
+        x1="80"
+        y1="320"
+        x2="920"
+        y2="320"
+        stroke="currentColor"
+        strokeWidth="2"
+        className="[stroke-dasharray:840] [stroke-dashoffset:calc(840*var(--dash))]"
+      />
+    </motion.svg>
+  );
+}
+


### PR DESCRIPTION
## Summary
- create scroll-driven hero with logo-to-wireframe court animation
- split server and client components to fix build error and support skip link targetting
- generate open graph images at runtime without committing binaries

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c3426663688332b0cf35bcdbd7c7f8