### PR TITLE
Refactor hero with scroll-driven padel court animation

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -20,13 +20,13 @@ export default function Home() {
         <div className="flex gap-4">
           <Link
             href="/membership"
-            className="inline-flex items-center rounded-2xl bg-white text-black px-6 py-3 font-medium hover:opacity-90 focus:outline-white/60 transition-transform duration-150 will-change-transform hover:-translate-y-0.5 hover:ring-1 hover:ring-white/20"
+            className="no-underline inline-flex items-center rounded-2xl bg-white text-black px-6 py-3 font-medium hover:opacity-90 focus:outline-white/60 transition-transform duration-150 will-change-transform hover:-translate-y-0.5 hover:ring-1 hover:ring-white/20"
           >
             Membership
           </Link>
           <Link
             href="/shop"
-            className="rounded-2xl border border-white/30 px-6 py-3 text-white hover:border-white/60 focus:outline-white/60 transition-transform duration-150 will-change-transform hover:-translate-y-0.5 hover:ring-1 hover:ring-white/20"
+            className="no-underline rounded-2xl border border-white/30 px-6 py-3 text-white hover:border-white/60 focus:outline-white/60 transition-transform duration-150 will-change-transform hover:-translate-y-0.5 hover:ring-1 hover:ring-white/20"
           >
             Shop
           </Link>

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,98 +1,143 @@
 "use client";
 
-import { useRef } from "react";
-import { motion, useScroll, useTransform, MotionValue } from "framer-motion";
+import { useRef, useEffect } from "react";
+import { motion, useScroll, useTransform, useAnimation } from "framer-motion";
 
 export default function Hero() {
   const ref = useRef<HTMLDivElement>(null);
-  const { scrollYProgress } = useScroll({ target: ref, offset: ["start start", "end start"] });
+  const { scrollYProgress } = useScroll({
+    target: ref,
+    offset: ["start start", "end start"],
+  });
 
-  const logoScale = useTransform(scrollYProgress, [0, 0.3], [1.2, 0.8]);
-  const logoOpacity = useTransform(scrollYProgress, [0, 0.3], [1, 0]);
-  const logoY = useTransform(scrollYProgress, [0, 0.3], ["0%", "-40%"]);
+  // Stage 1: logo fades and scales back
+  const logoScale = useTransform(scrollYProgress, [0, 1], [1, 0.7]);
+  const logoOpacity = useTransform(scrollYProgress, [0, 0.5, 1], [1, 0.4, 0]);
 
-  const courtOpacity = useTransform(scrollYProgress, [0.25, 0.6], [0, 1]);
-  const courtScale = useTransform(scrollYProgress, [0.3, 0.8], [0.9, 1]);
-  const courtY = useTransform(scrollYProgress, [0.3, 0.8], ["20%", "0%"]);
-  const dash = useTransform(scrollYProgress, [0.3, 0.8], [1, 0]);
+  // Stage 2: overhead lights
+  const light1 = useTransform(scrollYProgress, [0.2, 0.4], [0, 1]);
+  const light2 = useTransform(scrollYProgress, [0.23, 0.43], [0, 1]);
+  const light1Offset = useTransform(light1, [0, 1], [600, 0]);
+  const light2Offset = useTransform(light2, [0, 1], [600, 0]);
 
-  const imageOpacity = useTransform(scrollYProgress, [0.75, 1], [0, 1]);
+  // Stage 3: net line
+  const net = useTransform(scrollYProgress, [0.45, 0.65], [0, 1]);
+  const netOffset = useTransform(net, [0, 1], [800, 0]);
+
+  // Stage 4: court lines sequential
+  const linesTrigger = useTransform(scrollYProgress, [0.65, 0.66], [0, 1]);
+  const linesControls = useAnimation();
+  useEffect(() => {
+    return linesTrigger.on("change", (latest) => {
+      linesControls.start(latest > 0 ? "visible" : "hidden");
+    });
+  }, [linesControls, linesTrigger]);
+
+  const groupVariants = {
+    hidden: {},
+    visible: {
+      transition: { staggerChildren: 0.2 },
+    },
+  };
+
+  const lineVariants = {
+    hidden: (length: number) => ({ strokeDashoffset: length }),
+    visible: {
+      strokeDashoffset: 0,
+      transition: { duration: 0.8 },
+    },
+  };
 
   return (
     <section ref={ref} className="relative h-[200vh]">
-      <div className="sticky top-0 h-screen flex items-center justify-center overflow-hidden">
+      <div className="sticky top-0 h-screen flex items-center justify-center overflow-hidden bg-black text-white">
         <motion.h1
-          style={{ scale: logoScale, opacity: logoOpacity, y: logoY }}
-          className="text-6xl md:text-7xl tracking-tight"
+          style={{ scale: logoScale, opacity: logoOpacity }}
+          className="text-[clamp(48px,12vw,160px)] font-extrabold"
         >
           CLUB FORE
         </motion.h1>
 
-        <motion.div
-          style={{ opacity: courtOpacity, scale: courtScale, y: courtY }}
-          className="absolute inset-0 flex items-center justify-center"
+        <motion.svg
+          viewBox="0 0 1000 640"
+          className="absolute inset-0 w-full max-w-5xl mx-auto"
         >
-          <WireframeCourt progress={dash} />
-          <div
-            className="absolute inset-0 -z-10"
-            style={{
-              backgroundImage:
-                "radial-gradient(circle at center, rgba(255,255,255,0.08), transparent 70%)," +
-                "repeating-linear-gradient(rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)," +
-                "repeating-linear-gradient(90deg, rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)",
-            }}
+          {/* Overhead lights */}
+          <motion.line
+            x1="200"
+            x2="800"
+            y1="80"
+            y2="80"
+            stroke="currentColor"
+            strokeWidth="4"
+            strokeDasharray="600"
+            style={{ strokeDashoffset: light1Offset }}
           />
-        </motion.div>
+          <motion.line
+            x1="200"
+            x2="800"
+            y1="120"
+            y2="120"
+            stroke="currentColor"
+            strokeWidth="4"
+            strokeDasharray="600"
+            style={{ strokeDashoffset: light2Offset }}
+          />
 
-        <motion.div
+          {/* Net line */}
+          <motion.line
+            x1="100"
+            x2="900"
+            y1="320"
+            y2="320"
+            stroke="currentColor"
+            strokeWidth="2"
+            strokeDasharray="800"
+            style={{ strokeDashoffset: netOffset }}
+          />
+
+          {/* Court lines */}
+          <motion.g
+            variants={groupVariants}
+            initial="hidden"
+            animate={linesControls}
+            stroke="currentColor"
+            strokeWidth="2"
+            fill="none"
+          >
+            <motion.line
+              x1="500"
+              y1="60"
+              x2="500"
+              y2="580"
+              strokeDasharray="520"
+              variants={lineVariants}
+              custom={520}
+            />
+            <motion.rect
+              x="80"
+              y="60"
+              width="840"
+              height="520"
+              strokeDasharray="2720"
+              variants={lineVariants}
+              custom={2720}
+            />
+          </motion.g>
+        </motion.svg>
+
+        {/* Vignette + grid background */}
+        <div
+          className="absolute inset-0 -z-10"
           style={{
-            opacity: imageOpacity,
             backgroundImage:
-              "url(https://images.unsplash.com/photo-1555169062-013468b477d0?auto=format&fit=crop&w=1200&q=80)",
+              "radial-gradient(circle at center, rgba(255,255,255,0.08), transparent 70%)," +
+              "repeating-linear-gradient(rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)," +
+              "repeating-linear-gradient(90deg, rgba(255,255,255,0.05) 0 1px, transparent 1px 40px)",
           }}
-          className="absolute inset-0 bg-center bg-cover"
         />
       </div>
     </section>
-  );
-}
-
-function WireframeCourt({ progress }: { progress: MotionValue<number> }) {
-  return (
-    <motion.svg
-      viewBox="0 0 1000 640"
-      className="w-full max-w-5xl text-white"
-      style={{ "--dash": progress } as any}
-    >
-      <rect
-        x="80"
-        y="60"
-        width="840"
-        height="520"
-        stroke="currentColor"
-        strokeWidth="2"
-        fill="none"
-        className="[stroke-dasharray:1600] [stroke-dashoffset:calc(1600*var(--dash))]"
-      />
-      <line
-        x1="500"
-        y1="60"
-        x2="500"
-        y2="580"
-        stroke="currentColor"
-        strokeWidth="2"
-        className="[stroke-dasharray:1040] [stroke-dashoffset:calc(1040*var(--dash))]"
-      />
-      <line
-        x1="80"
-        y1="320"
-        x2="920"
-        y2="320"
-        stroke="currentColor"
-        strokeWidth="2"
-        className="[stroke-dasharray:840] [stroke-dashoffset:calc(840*var(--dash))]"
-      />
-    </motion.svg>
   );
 }
 


### PR DESCRIPTION
## Summary
- Rebuild hero as client component with scroll-driven transforms revealing a vector padel court
- Fade and scale logo while drawing overhead lights, net, and sequential court lines
- Remove link underlines in CTA to preserve clean focus styles

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c41556c97c833282dfa3e52507a269