### PR TITLE
feat: add scroll-driven hero

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,16 +2,14 @@ import type { Metadata } from "next";
 import Hero from "@/components/Hero";
 
 export const metadata: Metadata = {
-  description: "Precision. Power. Minimalism.",
-  openGraph: { images: ["/opengraph-image"] },
-  twitter: { images: ["/twitter-image"] }
+  title: "Club Fore",
+  description: "Members-only padel. Designed in London.",
 };
 
-export default function Home() {
+export default function Page() {
   return (
-    <main id="main">
+    <main className="bg-black text-white">
       <Hero />
     </main>
   );
 }
-

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -1,136 +1,219 @@
 "use client";
 
-import { useRef, useEffect } from "react";
-import { motion, useScroll, useTransform, useAnimation } from "framer-motion";
+import { useRef } from "react";
+import { motion, useScroll, useTransform, MotionValue } from "framer-motion";
 
+/**
+ * Cinematic, single-viewport hero:
+ * - Logo fades "into" the back wall
+ * - Two angled ceiling light strips descend
+ * - Court lines draw in with perspective to a vanishing point
+ * - No below-the-fold content; scroll only drives animation
+ */
 export default function Hero() {
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: ref,
-    offset: ["start start", "end start"],
+    offset: ["start start", "end start"], // 200vh scrub range
   });
 
-  const logoScale = useTransform(scrollYProgress, [0, 1], [1, 0.7]);
-  const logoOpacity = useTransform(scrollYProgress, [0, 0.3, 1], [1, 0.4, 0]);
+  // TIMING MAP (tweakable):
+  // 0.00–0.30  Logo recede/fade
+  // 0.30–0.55  Lights draw down
+  // 0.50–0.65  Net + back-wall line
+  // 0.60–1.00  Remaining court lines
 
-  const lightRange: [number, number] = [0.3, 0.5];
-  const lightY = useTransform(scrollYProgress, lightRange, [-400, 0]);
-  const lightOpacity = useTransform(scrollYProgress, lightRange, [0, 1]);
+  // Logo transforms
+  const logoScale = useTransform(scrollYProgress, [0, 0.3], [1, 0.72]);
+  const logoOpacity = useTransform(scrollYProgress, [0, 0.18, 0.3], [1, 0.55, 0]);
+  const logoY = useTransform(scrollYProgress, [0, 0.3], [0, -80]);
 
-  const linesTrigger = useTransform(scrollYProgress, [0.5, 1], [0, 1]);
-  const linesControls = useAnimation();
-  useEffect(() => {
-    return linesTrigger.on("change", (latest) => {
-      linesControls.start(latest > 0 ? "visible" : "hidden");
-    });
-  }, [linesTrigger, linesControls]);
+  // Light strips draw (0 -> 1)
+  const lightDraw = useTransform(scrollYProgress, [0.3, 0.55], [1, 0]); // dashoffset multiplier
 
-  const groupVariants = {
-    hidden: {},
-    visible: { transition: { staggerChildren: 0.2 } },
-  };
-
-  const lineVariants = {
-    hidden: { pathLength: 0 },
-    visible: { pathLength: 1, transition: { duration: 0.8 } },
-  };
+  // Lines draw windows
+  const netDraw   = useTransform(scrollYProgress, [0.5, 0.65], [1, 0]);
+  const linesDraw = useTransform(scrollYProgress, [0.6, 1.0], [1, 0]);
 
   return (
     <section ref={ref} className="relative h-[200vh]">
-      <div className="sticky top-0 h-screen flex items-center justify-center overflow-hidden bg-black text-white">
-        <motion.h1
-          style={{ scale: logoScale, opacity: logoOpacity }}
-          className="absolute text-[clamp(48px,12vw,160px)] font-extrabold"
-        >
-          CLUB FORE
-        </motion.h1>
-
-        <motion.svg
-          viewBox="0 0 1000 600"
-          className="absolute inset-0 w-full h-full max-w-5xl mx-auto"
-        >
-          {/* Lights */}
-          <motion.rect
-            x="220"
-            width="40"
-            height="400"
-            fill="currentColor"
-            style={{
-              y: lightY,
-              opacity: lightOpacity,
-              rotate: -10,
-              originY: 0,
-            }}
-          />
-          <motion.rect
-            x="740"
-            width="40"
-            height="400"
-            fill="currentColor"
-            style={{
-              y: lightY,
-              opacity: lightOpacity,
-              rotate: 10,
-              originY: 0,
-            }}
-          />
-
-          {/* Court lines */}
-          <motion.g
-            stroke="currentColor"
-            strokeWidth="2"
-            fill="none"
-            variants={groupVariants}
-            initial="hidden"
-            animate={linesControls}
-          >
-            {/* Net line */}
-            <motion.line
-              x1="100"
-              y1="320"
-              x2="900"
-              y2="280"
-              strokeDasharray="1"
-              variants={lineVariants}
-            />
-            {/* Center line */}
-            <motion.line
-              x1="500"
-              y1="280"
-              x2="500"
-              y2="600"
-              strokeDasharray="1"
-              variants={lineVariants}
-            />
-            {/* Sidelines */}
-            <motion.line
-              x1="180"
-              y1="600"
-              x2="320"
-              y2="280"
-              strokeDasharray="1"
-              variants={lineVariants}
-            />
-            <motion.line
-              x1="820"
-              y1="600"
-              x2="680"
-              y2="280"
-              strokeDasharray="1"
-              variants={lineVariants}
-            />
-          </motion.g>
-        </motion.svg>
-
+      <div className="sticky top-0 h-screen overflow-hidden">
+        {/* Digital room vignette (pure CSS) */}
         <div
-          className="absolute inset-0 -z-10"
+          aria-hidden
+          className="absolute inset-0 pointer-events-none"
           style={{
             background:
-              "radial-gradient(800px 400px at 50% 80%, rgba(255,255,255,0.05), transparent 70%)",
+              "radial-gradient(1200px 700px at 50% 85%, rgba(255,255,255,0.06), transparent 60%)",
           }}
         />
+        {/* Subtle grid for structure */}
+        <div
+          aria-hidden
+          className="absolute inset-0 opacity-15"
+          style={{
+            backgroundImage:
+              `linear-gradient(to right, rgba(255,255,255,0.06) 1px, transparent 1px),
+               linear-gradient(to bottom, rgba(255,255,255,0.06) 1px, transparent 1px)`,
+            backgroundSize: "48px 48px, 48px 48px",
+          }}
+        />
+
+        {/* Center stack */}
+        <div className="relative z-10 grid place-items-center h-full">
+          {/* LOGO */}
+          <motion.h1
+            style={{ scale: logoScale, opacity: logoOpacity, y: logoY }}
+            className="select-none text-[clamp(56px,12vw,160px)] font-extrabold tracking-tight leading-[0.9] will-change-transform"
+          >
+            CLUB FORE
+          </motion.h1>
+
+          {/* SVG SCENE */}
+          <SceneSVG
+            lightDraw={lightDraw}
+            netDraw={netDraw}
+            linesDraw={linesDraw}
+          />
+        </div>
       </div>
     </section>
   );
 }
 
+function SceneSVG({
+  lightDraw,
+  netDraw,
+  linesDraw,
+}: {
+  lightDraw: MotionValue<number>;
+  netDraw: MotionValue<number>;
+  linesDraw: MotionValue<number>;
+}) {
+  // Vanishing point tuned to match the reference render
+  const VP = { x: 500, y: 190 };
+
+  return (
+    <motion.svg
+      viewBox="0 0 1000 640"
+      className="absolute inset-0 m-auto max-w-[96vw] max-h-[80vh]"
+      // Bind dash variables to MotionValues for all paths
+      style={
+        {
+          // @ts-ignore custom props
+          "--dashLights": lightDraw,
+          "--dashNet": netDraw,
+          "--dashLines": linesDraw,
+        } as any
+      }
+      aria-hidden
+    >
+      <Defs />
+
+      {/* CEILING LIGHT STRIPS (angled, receding) */}
+      <g filter="url(#glow)">
+        {/* Left strip: from ceiling to near vanishing layer */}
+        <motion.line
+          x1={320}
+          y1={-40}
+          x2={300}
+          y2={VP.y}
+          stroke="white"
+          strokeWidth={6}
+          className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLights))]"
+          strokeLinecap="round"
+        />
+        {/* Right strip */}
+        <motion.line
+          x1={680}
+          y1={-40}
+          x2={700}
+          y2={VP.y}
+          stroke="white"
+          strokeWidth={6}
+          className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLights))]"
+          strokeLinecap="round"
+        />
+      </g>
+
+      {/* COURT LINES */}
+      <g mask="url(#depth)" stroke="white">
+        {/* Back-wall base line (thin, near VP) */}
+        <motion.line
+          x1={160}
+          y1={VP.y + 40}
+          x2={840}
+          y2={VP.y + 40}
+          strokeWidth={1.5}
+          className="[stroke-dasharray:800] [stroke-dashoffset:calc(800*var(--dashLines))]"
+        />
+
+        {/* NET (slight perspective tilt) */}
+        <motion.line
+          x1={120}
+          y1={380}
+          x2={880}
+          y2={370}
+          strokeWidth={2.5}
+          className="[stroke-dasharray:820] [stroke-dashoffset:calc(820*var(--dashNet))]"
+        />
+
+        {/* CENTER LINE (from back wall toward camera) */}
+        <motion.line
+          x1={VP.x}
+          y1={VP.y + 40}
+          x2={VP.x}
+          y2={620}
+          strokeWidth={3}
+          className="[stroke-dasharray:460] [stroke-dashoffset:calc(460*var(--dashLines))]"
+        />
+
+        {/* LEFT SIDELINE (converging) */}
+        <motion.line
+          x1={200}
+          y1={VP.y + 50}
+          x2={80}
+          y2={620}
+          strokeWidth={2.5}
+          className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLines))]"
+        />
+
+        {/* RIGHT SIDELINE (converging) */}
+        <motion.line
+          x1={800}
+          y1={VP.y + 50}
+          x2={920}
+          y2={620}
+          strokeWidth={2.5}
+          className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLines))]"
+        />
+      </g>
+    </motion.svg>
+  );
+}
+
+/** SVG defs: depth mask + subtle glow for lights */
+function Defs() {
+  return (
+    <defs>
+      {/* Alpha mask: receding lines fade very slightly toward the top */}
+      <mask id="depth">
+        <linearGradient id="fadeY" x1="0" x2="0" y1="0" y2="1">
+          <stop offset="0%" stopColor="white" stopOpacity="0.65" />
+          <stop offset="50%" stopColor="white" stopOpacity="0.85" />
+          <stop offset="100%" stopColor="white" stopOpacity="1" />
+        </linearGradient>
+        <rect x="0" y="0" width="1000" height="640" fill="url(#fadeY)" />
+      </mask>
+
+      {/* Light glow (very restrained to keep it luxury/minimal) */}
+      <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+        <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur" />
+        <feMerge>
+          <feMergeNode in="blur" />
+          <feMergeNode in="SourceGraphic" />
+        </feMerge>
+      </filter>
+    </defs>
+  );
+}


### PR DESCRIPTION
## Summary
- replace home page with server component mounting the new `Hero`
- implement scroll-driven padel court hero using Framer Motion and SVG

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c41b5d32808332bd260b302355cb3b