### PR TITLE
feat: cinematic hero with realistic perspective lines (logo fades to wall, angled lights, net & sidelines), no binary assets

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -3,42 +3,26 @@
 import { useRef } from "react";
 import { motion, useScroll, useTransform, MotionValue } from "framer-motion";
 
-/**
- * Cinematic, single-viewport hero:
- * - Logo fades "into" the back wall
- * - Two angled ceiling light strips descend
- * - Court lines draw in with perspective to a vanishing point
- * - No below-the-fold content; scroll only drives animation
- */
 export default function Hero() {
   const ref = useRef<HTMLDivElement>(null);
   const { scrollYProgress } = useScroll({
     target: ref,
-    offset: ["start start", "end start"], // 200vh scrub range
+    offset: ["start start", "end start"],
   });
 
-  // TIMING MAP (tweakable):
-  // 0.00–0.30  Logo recede/fade
-  // 0.30–0.55  Lights draw down
-  // 0.50–0.65  Net + back-wall line
-  // 0.60–1.00  Remaining court lines
-
-  // Logo transforms
+  // Scroll segments
   const logoScale = useTransform(scrollYProgress, [0, 0.3], [1, 0.72]);
   const logoOpacity = useTransform(scrollYProgress, [0, 0.18, 0.3], [1, 0.55, 0]);
   const logoY = useTransform(scrollYProgress, [0, 0.3], [0, -80]);
 
-  // Light strips draw (0 -> 1)
-  const lightDraw = useTransform(scrollYProgress, [0.3, 0.55], [1, 0]); // dashoffset multiplier
-
-  // Lines draw windows
-  const netDraw   = useTransform(scrollYProgress, [0.5, 0.65], [1, 0]);
-  const linesDraw = useTransform(scrollYProgress, [0.6, 1.0], [1, 0]);
+  const lightsDash = useTransform(scrollYProgress, [0.3, 0.55], [1, 0]);
+  const netDash = useTransform(scrollYProgress, [0.5, 0.65], [1, 0]);
+  const linesDash = useTransform(scrollYProgress, [0.6, 1.0], [1, 0]);
 
   return (
     <section ref={ref} className="relative h-[200vh]">
       <div className="sticky top-0 h-screen overflow-hidden">
-        {/* Digital room vignette (pure CSS) */}
+        {/* Vignette */}
         <div
           aria-hidden
           className="absolute inset-0 pointer-events-none"
@@ -47,34 +31,26 @@ export default function Hero() {
               "radial-gradient(1200px 700px at 50% 85%, rgba(255,255,255,0.06), transparent 60%)",
           }}
         />
-        {/* Subtle grid for structure */}
+        {/* Grid */}
         <div
           aria-hidden
           className="absolute inset-0 opacity-15"
           style={{
             backgroundImage:
-              `linear-gradient(to right, rgba(255,255,255,0.06) 1px, transparent 1px),
-               linear-gradient(to bottom, rgba(255,255,255,0.06) 1px, transparent 1px)`,
+              `linear-gradient(to right, rgba(255,255,255,0.06) 1px, transparent 1px),` +
+              `linear-gradient(to bottom, rgba(255,255,255,0.06) 1px, transparent 1px)`,
             backgroundSize: "48px 48px, 48px 48px",
           }}
         />
-
-        {/* Center stack */}
-        <div className="relative z-10 grid place-items-center h-full">
-          {/* LOGO */}
+        {/* Content */}
+        <div className="relative z-10 grid h-full place-items-center">
           <motion.h1
             style={{ scale: logoScale, opacity: logoOpacity, y: logoY }}
-            className="select-none text-[clamp(56px,12vw,160px)] font-extrabold tracking-tight leading-[0.9] will-change-transform"
+            className="select-none text-[clamp(56px,12vw,160px)] font-extrabold tracking-tight leading-[0.9] [will-change:transform]"
           >
             CLUB FORE
           </motion.h1>
-
-          {/* SVG SCENE */}
-          <SceneSVG
-            lightDraw={lightDraw}
-            netDraw={netDraw}
-            linesDraw={linesDraw}
-          />
+          <SceneSVG lightsDash={lightsDash} netDash={netDash} linesDash={linesDash} />
         </div>
       </div>
     </section>
@@ -82,138 +58,106 @@ export default function Hero() {
 }
 
 function SceneSVG({
-  lightDraw,
-  netDraw,
-  linesDraw,
+  lightsDash,
+  netDash,
+  linesDash,
 }: {
-  lightDraw: MotionValue<number>;
-  netDraw: MotionValue<number>;
-  linesDraw: MotionValue<number>;
+  lightsDash: MotionValue<number>;
+  netDash: MotionValue<number>;
+  linesDash: MotionValue<number>;
 }) {
-  // Vanishing point tuned to match the reference render
   const VP = { x: 500, y: 190 };
-
   return (
     <motion.svg
       viewBox="0 0 1000 640"
       className="absolute inset-0 m-auto max-w-[96vw] max-h-[80vh]"
-      // Bind dash variables to MotionValues for all paths
-      style={
-        {
-          // @ts-ignore custom props
-          "--dashLights": lightDraw,
-          "--dashNet": netDraw,
-          "--dashLines": linesDraw,
-        } as any
-      }
+      style={{
+        "--dashLights": lightsDash,
+        "--dashNet": netDash,
+        "--dashLines": linesDash,
+      } as any}
       aria-hidden
     >
-      <Defs />
-
-      {/* CEILING LIGHT STRIPS (angled, receding) */}
+      <defs>
+        <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
+          <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur" />
+          <feMerge>
+            <feMergeNode in="blur" />
+            <feMergeNode in="SourceGraphic" />
+          </feMerge>
+        </filter>
+      </defs>
+      {/* Overhead lights */}
       <g filter="url(#glow)">
-        {/* Left strip: from ceiling to near vanishing layer */}
         <motion.line
-          x1={320}
+          x1={260}
           y1={-40}
-          x2={300}
+          x2={240}
           y2={VP.y}
           stroke="white"
-          strokeWidth={6}
+          strokeWidth={4}
           className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLights))]"
           strokeLinecap="round"
         />
-        {/* Right strip */}
         <motion.line
-          x1={680}
+          x1={740}
           y1={-40}
-          x2={700}
+          x2={760}
           y2={VP.y}
           stroke="white"
-          strokeWidth={6}
+          strokeWidth={4}
           className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLights))]"
           strokeLinecap="round"
         />
       </g>
-
-      {/* COURT LINES */}
-      <g mask="url(#depth)" stroke="white">
-        {/* Back-wall base line (thin, near VP) */}
-        <motion.line
-          x1={160}
-          y1={VP.y + 40}
-          x2={840}
-          y2={VP.y + 40}
-          strokeWidth={1.5}
-          className="[stroke-dasharray:800] [stroke-dashoffset:calc(800*var(--dashLines))]"
-        />
-
-        {/* NET (slight perspective tilt) */}
-        <motion.line
-          x1={120}
-          y1={380}
-          x2={880}
-          y2={370}
-          strokeWidth={2.5}
-          className="[stroke-dasharray:820] [stroke-dashoffset:calc(820*var(--dashNet))]"
-        />
-
-        {/* CENTER LINE (from back wall toward camera) */}
-        <motion.line
-          x1={VP.x}
-          y1={VP.y + 40}
-          x2={VP.x}
-          y2={620}
-          strokeWidth={3}
-          className="[stroke-dasharray:460] [stroke-dashoffset:calc(460*var(--dashLines))]"
-        />
-
-        {/* LEFT SIDELINE (converging) */}
-        <motion.line
-          x1={200}
-          y1={VP.y + 50}
-          x2={80}
-          y2={620}
-          strokeWidth={2.5}
-          className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLines))]"
-        />
-
-        {/* RIGHT SIDELINE (converging) */}
-        <motion.line
-          x1={800}
-          y1={VP.y + 50}
-          x2={920}
-          y2={620}
-          strokeWidth={2.5}
-          className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLines))]"
-        />
-      </g>
+      {/* Net */}
+      <motion.line
+        x1={140}
+        y1={400}
+        x2={860}
+        y2={390}
+        stroke="white"
+        strokeWidth={2.5}
+        className="[stroke-dasharray:800] [stroke-dashoffset:calc(800*var(--dashNet))]"
+      />
+      {/* Court lines */}
+      <motion.line
+        x1={VP.x}
+        y1={VP.y + 40}
+        x2={VP.x}
+        y2={620}
+        stroke="white"
+        strokeWidth={3}
+        className="[stroke-dasharray:460] [stroke-dashoffset:calc(460*var(--dashLines))]"
+      />
+      <motion.line
+        x1={200}
+        y1={VP.y + 50}
+        x2={100}
+        y2={620}
+        stroke="white"
+        strokeWidth={2.5}
+        className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLines))]"
+      />
+      <motion.line
+        x1={800}
+        y1={VP.y + 50}
+        x2={900}
+        y2={620}
+        stroke="white"
+        strokeWidth={2.5}
+        className="[stroke-dasharray:520] [stroke-dashoffset:calc(520*var(--dashLines))]"
+      />
+      <motion.line
+        x1={180}
+        y1={VP.y + 40}
+        x2={820}
+        y2={VP.y + 40}
+        stroke="white"
+        strokeWidth={1.5}
+        className="[stroke-dasharray:640] [stroke-dashoffset:calc(640*var(--dashLines))]"
+      />
     </motion.svg>
   );
 }
 
-/** SVG defs: depth mask + subtle glow for lights */
-function Defs() {
-  return (
-    <defs>
-      {/* Alpha mask: receding lines fade very slightly toward the top */}
-      <mask id="depth">
-        <linearGradient id="fadeY" x1="0" x2="0" y1="0" y2="1">
-          <stop offset="0%" stopColor="white" stopOpacity="0.65" />
-          <stop offset="50%" stopColor="white" stopOpacity="0.85" />
-          <stop offset="100%" stopColor="white" stopOpacity="1" />
-        </linearGradient>
-        <rect x="0" y="0" width="1000" height="640" fill="url(#fadeY)" />
-      </mask>
-
-      {/* Light glow (very restrained to keep it luxury/minimal) */}
-      <filter id="glow" x="-20%" y="-20%" width="140%" height="140%">
-        <feGaussianBlur in="SourceGraphic" stdDeviation="2" result="blur" />
-        <feMerge>
-          <feMergeNode in="blur" />
-          <feMergeNode in="SourceGraphic" />
-        </feMerge>
-      </filter>
-    </defs>
-  );
-}


### PR DESCRIPTION
## Summary
- replace hero with framer‑motion scene that scrubs via sticky 200vh container
- add radial vignette, faint grid, and perspective SVG lines converging to a vanishing point
- ensure home page renders only the animated hero

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c41e0540d883329a6f3564112e9e9e