### PR TITLE
chore: update homepage tagline

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -3,7 +3,7 @@ import Hero from "@/components/Hero";
 
 export const metadata: Metadata = {
   title: "Club Fore",
-  description: "Scroll-driven cinematic padel court",
+  description: "Members-only padel. Designed in London.",
 };
 
 export default function Page() {


### PR DESCRIPTION
## Summary
- replace homepage metadata description with a club-wide tagline

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c539d18e6c8332b2bfdb9338d63c25