### PR TITLE
feat: center hero logo and add sidelines

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,6 +9,28 @@ html, body {
   color: #fff;
 }
 
+html {
+  --side-line-offset: 40px;
+}
+
+body::before,
+body::after {
+  content: "";
+  position: fixed;
+  top: 0;
+  bottom: 0;
+  width: 2px;
+  background: rgba(255, 255, 255, 0.2);
+  pointer-events: none;
+  z-index: 10;
+}
+body::before {
+  left: var(--side-line-offset);
+}
+body::after {
+  right: var(--side-line-offset);
+}
+
 a {
   color: #fff;
   text-decoration: none;

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -33,7 +33,7 @@ export default function Hero() {
     function resize() {
       const dpr = Math.max(1, window.devicePixelRatio || 1);
       canvas.width = Math.floor(window.innerWidth * dpr);
-      canvas.height = Math.floor(window.innerHeight * dpr * 0.9);
+      canvas.height = Math.floor(window.innerHeight * dpr);
       ctx.setTransform(1, 0, 0, 1, 0, 0);
       ctx.scale(dpr, dpr);
     }
@@ -151,7 +151,7 @@ export default function Hero() {
         vh = window.innerHeight - pad * 2;
       const S = Math.min(vw / (COURT.W * 1.1), vh / (COURT.ceilingH * 2.0));
       const cx = window.innerWidth / 2,
-        cy = window.innerHeight * 0.75;
+        cy = window.innerHeight * 0.6;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.lineJoin = "round";
       ctx.lineCap = "round";


### PR DESCRIPTION
## Summary
- reposition hero canvas and logo to start higher on page
- add vertical sidelines framing the page

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c549c0d1a88332b9b1e74df9be04f0