### PR TITLE
feat: center hero logo and add court sidelines

### DIFF
--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -33,7 +33,7 @@ export default function Hero() {
     function resize() {
       const dpr = Math.max(1, window.devicePixelRatio || 1);
       canvas.width = Math.floor(window.innerWidth * dpr);
-      canvas.height = Math.floor(window.innerHeight * dpr * 0.9);
+      canvas.height = Math.floor(window.innerHeight * dpr);
       ctx.setTransform(1, 0, 0, 1, 0, 0);
       ctx.scale(dpr, dpr);
     }
@@ -124,10 +124,11 @@ export default function Hero() {
       }
       const s1x = L / 2 - COURT.serviceFromNet,
         s2x = L / 2 + COURT.serviceFromNet;
+      const halfLine = COURT.lineWidth / 2;
       const lines = [
-        // sidelines
-        [{ x: 0, y: 0, z: 0 }, { x: L, y: 0, z: 0 }],
-        [{ x: 0, y: W, z: 0 }, { x: L, y: W, z: 0 }],
+        // sidelines (slightly inset from outer edge)
+        [{ x: 0, y: halfLine, z: 0 }, { x: L, y: halfLine, z: 0 }],
+        [{ x: 0, y: W - halfLine, z: 0 }, { x: L, y: W - halfLine, z: 0 }],
         // baselines
         [{ x: 0, y: 0, z: 0 }, { x: 0, y: W, z: 0 }],
         [{ x: L, y: 0, z: 0 }, { x: L, y: W, z: 0 }],
@@ -151,7 +152,7 @@ export default function Hero() {
         vh = window.innerHeight - pad * 2;
       const S = Math.min(vw / (COURT.W * 1.1), vh / (COURT.ceilingH * 2.0));
       const cx = window.innerWidth / 2,
-        cy = window.innerHeight * 0.75;
+        cy = window.innerHeight * 0.6;
       ctx.clearRect(0, 0, canvas.width, canvas.height);
       ctx.lineJoin = "round";
       ctx.lineCap = "round";


### PR DESCRIPTION
## Summary
- reposition hero canvas and logo to start higher on page
- draw visible court sidelines instead of page decorations

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c549c0d1a88332b9b1e74df9be04f0