### PR TITLE
Remove decorative lines and improve mobile viewport

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -9,27 +9,6 @@ html, body {
   color: #fff;
 }
 
-html {
-  --side-line-offset: 40px;
-}
-
-body::before,
-body::after {
-  content: "";
-  position: fixed;
-  top: 0;
-  bottom: 0;
-  width: 2px;
-  background: rgba(255, 255, 255, 0.2);
-  pointer-events: none;
-  z-index: 10;
-}
-body::before {
-  left: var(--side-line-offset);
-}
-body::after {
-  right: var(--side-line-offset);
-}
 
 a {
   color: #fff;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,5 @@
 import "./globals.css";
-import type { Metadata } from "next";
+import type { Metadata, Viewport } from "next";
 import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 
@@ -8,6 +8,11 @@ export const metadata: Metadata = {
   description: "Precision. Power. Minimalism.",
   openGraph: { title: "Club Fore", description: "Precision. Power. Minimalism.", images: ["/opengraph-image"] },
   twitter: { card: "summary_large_image", images: ["/twitter-image"] }
+};
+
+export const viewport: Viewport = {
+  width: "device-width",
+  initialScale: 1,
 };
 
 export default function RootLayout({ children }: { children: React.ReactNode }) {

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -161,10 +161,7 @@ export default function Hero() {
         [{ x: s1x, y: W / 2, z: 0 }, { x: L / 2, y: W / 2, z: 0 }],
         [{ x: L / 2, y: W / 2, z: 0 }, { x: s2x, y: W / 2, z: 0 }],
       ];
-      const strips: any[] = [];
-      for (let y = 3; y < W; y += 4)
-        strips.push([{ x: 0, y: y, z: COURT.ceilingH }, { x: L, y: y, z: COURT.ceilingH }]);
-      return { segments: g, lines, netPts, strips };
+      return { segments: g, lines, netPts };
     }
     const model = build();
 
@@ -222,7 +219,6 @@ export default function Hero() {
         );
       }
       drawPolyline(model.netPts, S, cx, cy, 2, "#fff");
-      for (const strip of model.strips) drawSegment(strip[0], strip[1], S, cx, cy, 5, "#888");
     }
 
     function loop() {
@@ -237,6 +233,6 @@ export default function Hero() {
     };
   }, []);
 
-  return <canvas ref={canvasRef} className="w-screen h-screen bg-black" />;
+  return <canvas ref={canvasRef} className="block w-dvw h-dvh bg-black" />;
 }
 


### PR DESCRIPTION
## Summary
- eliminate side-border pseudo-elements from global styles
- drop ceiling light strips from Hero animation
- add mobile-friendly viewport settings and dynamic canvas sizing

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5933754588332b201d07934a8f02c