### PR TITLE
Refresh site copy and navigation

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -2,7 +2,8 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "About",
-  description: "Minimalist padel gear designed in London, played everywhere.",
+  description:
+    "Club Fore was founded on a simple idea: padel deserves a setting as inspiring as the sport itself.",
   openGraph: { images: ["/opengraph-image"] },
   twitter: { images: ["/twitter-image"] }
 };
@@ -10,12 +11,19 @@ export const metadata: Metadata = {
 export default function AboutPage() {
   return (
     <div id="main" className="max-w-2xl mx-auto px-4 py-24 space-y-6">
-      <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">About Club Fore</h1>
+      <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">About Us</h1>
       <div className="max-w-[72ch] space-y-6 md:space-y-8">
-        <p>We strip everything back to what matters: feel, balance, longevity.</p>
-        <p>Every product starts on court and ends in your hand.</p>
+        <p>
+          Club Fore was founded on a simple idea: padel deserves a setting as inspiring as the
+          sport itself. Our clubs are designed with clarity, balance, and detail in mind — courts
+          that play beautifully, atmospheres that feel effortless, and a culture built around the joy
+          of play.
+        </p>
+        <p>
+          Padel is more than competition. It’s connection, rhythm, and energy shared. Club Fore is
+          where that spirit comes to life.
+        </p>
       </div>
-      <p className="text-white/60">Designed in London. Played everywhere.</p>
     </div>
   );
 }

--- a/app/membership/page.tsx
+++ b/app/membership/page.tsx
@@ -4,7 +4,8 @@ import { ApplyButton } from "./ApplyButton";
 
 export const metadata: Metadata = {
   title: "Membership",
-  description: "Join a private network for players who value focus over noise.",
+  description:
+    "Membership at Club Fore is designed to fit how you play, with three tiers balancing access, flexibility, and community.",
   openGraph: { images: ["/opengraph-image"] },
   twitter: { images: ["/twitter-image"] }
 };
@@ -12,25 +13,38 @@ export const metadata: Metadata = {
 export default function MembershipPage() {
   return (
     <div id="main" className="max-w-4xl mx-auto px-4 py-24 space-y-8">
-      <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">Membership at Club Fore</h1>
+      <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">Membership</h1>
       <div className="max-w-[72ch] space-y-6 md:space-y-8">
-        <p>A private network for players who value focus over noise.</p>
+        <p>
+          Membership at Club Fore is designed to fit how you play, with three tiers balancing access,
+          flexibility, and community.
+        </p>
       </div>
       <div className="grid gap-8 md:grid-cols-3">
         <div>
-          <div className="font-semibold">Standard</div>
-          <p className="text-sm text-white/70">Priority booking, member rates.</p>
+          <div className="font-semibold">Core — £95/month</div>
+          <p className="text-sm text-white/70">
+            Straightforward access with priority booking (off-peak + selected peak), member
+            matchplay evenings, coaching eligibility, and member-rate merchandise.
+          </p>
         </div>
         <div>
-          <div className="font-semibold">Premium</div>
-          <p className="text-sm text-white/70">Extended access, guest passes, event invites.</p>
+          <div className="font-semibold">Plus — £150/month</div>
+          <p className="text-sm text-white/70">
+            Full flexibility with priority booking at all times, seasonal events, two monthly guest
+            passes, coaching discounts, and early access to new products.
+          </p>
         </div>
         <div>
-          <div className="font-semibold">Founders</div>
-          <p className="text-sm text-white/70">Lifetime perks, limited availability.</p>
+          <div className="font-semibold">Premier — £250/month</div>
+          <p className="text-sm text-white/70">
+            The complete experience: unlimited priority booking, quarterly coaching consultations,
+            exclusive events, four monthly guest passes, first access to collaborations, and concierge
+            support.
+          </p>
         </div>
       </div>
-      <p className="text-sm text-white/70">Spaces are limited. Applications reviewed weekly.</p>
+      <p className="text-sm text-white/70">Annual membership is available at preferential rates.</p>
       <div className="border-t border-white/10 mt-12 pt-8 space-y-4">
         <ApplyButton />
         <Link href="/contact?reason=membership" className="text-sm focus:outline-white/60">

--- a/components/Footer.tsx
+++ b/components/Footer.tsx
@@ -16,7 +16,7 @@ export function Footer() {
   return (
     <footer className="border-t border-white/10 mt-16">
       <div className="mx-auto max-w-6xl px-4 py-6 flex flex-col gap-4 md:flex-row md:items-center md:justify-between text-white">
-        <p className="text-sm">Club Fore — Precision meets power.</p>
+        <p className="text-sm">Designed in London. Played everywhere.</p>
         {sent ? (
           <p className="text-sm">Thanks — you’re on the list.</p>
         ) : (

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -11,14 +11,14 @@ export function Navbar() {
           CLUB FORE
         </Link>
         <nav className="hidden md:flex gap-6 text-sm">
-          <Link href="/membership" className="focus:outline-white/60">
-            Membership
+          <Link href="/about" className="focus:outline-white/60">
+            About
           </Link>
           <Link href="/shop" className="focus:outline-white/60">
             Shop
           </Link>
-          <Link href="/about" className="focus:outline-white/60">
-            About
+          <Link href="/membership" className="focus:outline-white/60">
+            Membership
           </Link>
         </nav>
         <button
@@ -32,11 +32,11 @@ export function Navbar() {
       {open && (
         <div className="md:hidden bg-black text-white divide-y divide-white/10">
           <Link
-            href="/membership"
+            href="/about"
             className="block px-4 py-4 focus:outline-white/60"
             onClick={() => setOpen(false)}
           >
-            Membership
+            About
           </Link>
           <Link
             href="/shop"
@@ -46,11 +46,11 @@ export function Navbar() {
             Shop
           </Link>
           <Link
-            href="/about"
+            href="/membership"
             className="block px-4 py-4 focus:outline-white/60"
             onClick={() => setOpen(false)}
           >
-            About
+            Membership
           </Link>
         </div>
       )}


### PR DESCRIPTION
## Summary
- replace footer tagline with "Designed in London. Played everywhere."
- reorder navigation links to About, Shop, Membership
- rewrite About and Membership pages with new club copy

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5b1390dfc83329058f105c6cdd639