### PR TITLE
Add shop merchandise data with pricing

### DIFF
--- a/app/shop/ProductGrid.tsx
+++ b/app/shop/ProductGrid.tsx
@@ -6,6 +6,8 @@ import products from "@/data/products.json";
 type Product = {
   id: number;
   name: string;
+  price: number;
+  description: string;
   images: string[];
 };
 
@@ -44,9 +46,10 @@ export function ProductGrid() {
               height={400}
               className="w-full h-48 object-cover bg-neutral-950"
             />
-            <div className="p-4">
-              <div className="text-sm uppercase tracking-wide text-white/80">{p.name}</div>
-            </div>
+              <div className="p-4">
+                <div className="text-sm uppercase tracking-wide text-white/80">{p.name}</div>
+                <div className="text-sm text-white/60 mt-1">${p.price}</div>
+              </div>
           </button>
         ))}
       </div>
@@ -57,7 +60,8 @@ export function ProductGrid() {
             className="w-full max-w-md space-y-4 bg-neutral-950 border border-white/10 rounded-2xl p-6"
           >
             <h2 className="text-xl font-semibold">Register Interest</h2>
-            <p className="text-sm text-white/70">{selected.name}</p>
+            <p className="text-sm text-white/70">{selected.name} – ${selected.price}</p>
+            <p className="text-sm text-white/70">{selected.description}</p>
             <input
               type="text"
               required

--- a/data/products.json
+++ b/data/products.json
@@ -1,26 +1,58 @@
 [
   {
     "id": 1,
-    "slug": "precision-pro",
-    "name": "Precision Pro",
-    "price": 199,
-    "images": ["/logo.svg"],
-    "specs": { "surface": "Carbon Fiber" }
+    "slug": "cap",
+    "name": "Club Fore Cap",
+    "price": 25,
+    "description": "Breathable performance cap with subtle Club Fore branding.",
+    "images": ["/logo.svg"]
   },
   {
     "id": 2,
-    "slug": "control-x",
-    "name": "Control X",
-    "price": 179,
-    "images": ["/logo.svg"],
-    "specs": { "surface": "Fiberglass" }
+    "slug": "shirt",
+    "name": "Club Fore Shirt",
+    "price": 35,
+    "description": "Lightweight moisture-wicking tee for training and match day.",
+    "images": ["/logo.svg"]
   },
   {
     "id": 3,
-    "slug": "power-lite",
-    "name": "Power Lite",
-    "price": 149,
-    "images": ["/logo.svg"],
-    "specs": { "surface": "Hybrid" }
+    "slug": "shoes",
+    "name": "Court Shoes",
+    "price": 120,
+    "description": "All-court shoes with responsive cushioning and durable grip.",
+    "images": ["/logo.svg"]
+  },
+  {
+    "id": 4,
+    "slug": "racket",
+    "name": "Club Fore Racket",
+    "price": 150,
+    "description": "Balanced padel racket engineered for control and power.",
+    "images": ["/logo.svg"]
+  },
+  {
+    "id": 5,
+    "slug": "hoodie",
+    "name": "Club Fore Hoodie",
+    "price": 60,
+    "description": "Soft fleece hoodie with clean monochrome lines.",
+    "images": ["/logo.svg"]
+  },
+  {
+    "id": 6,
+    "slug": "towel",
+    "name": "Microfiber Towel",
+    "price": 20,
+    "description": "Quick-drying microfiber towel sized for courtside use.",
+    "images": ["/logo.svg"]
+  },
+  {
+    "id": 7,
+    "slug": "water-bottle",
+    "name": "Water Bottle",
+    "price": 15,
+    "description": "Insulated stainless steel bottle that keeps drinks cold for hours.",
+    "images": ["/logo.svg"]
   }
 ]


### PR DESCRIPTION
## Summary
- add merch items (cap, shirt, shoes, racket, hoodie, towel, bottle) to products catalog
- show price and description in shop grid and modal

## Testing
- `npm test`
- `npm run lint`
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c5b65c588c833281945b9e529f4dec