### PR TITLE
Update branding to Courtier

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-# ClubFore - This is a Padel Club Website
+# Courtier - This is a Padel Club Website

--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -3,7 +3,7 @@ import type { Metadata } from "next";
 export const metadata: Metadata = {
   title: "About",
   description:
-    "Club Fore was founded on a simple idea: padel deserves a setting as inspiring as the sport itself.",
+    "Courtier was founded on a simple idea: padel deserves a setting as inspiring as the sport itself.",
   openGraph: { images: ["/opengraph-image"] },
   twitter: { images: ["/twitter-image"] }
 };
@@ -14,13 +14,13 @@ export default function AboutPage() {
       <h1 className="text-6xl md:text-7xl tracking-tight leading-[0.95]">About Us</h1>
       <div className="max-w-[72ch] space-y-6 md:space-y-8">
         <p>
-          Club Fore was founded on a simple idea: padel deserves a setting as inspiring as the
+          Courtier was founded on a simple idea: padel deserves a setting as inspiring as the
           sport itself. Our clubs are designed with clarity, balance, and detail in mind — courts
           that play beautifully, atmospheres that feel effortless, and a culture built around the joy
           of play.
         </p>
         <p>
-          Padel is more than competition. It’s connection, rhythm, and energy shared. Club Fore is
+          Padel is more than competition. It’s connection, rhythm, and energy shared. Courtier is
           where that spirit comes to life.
         </p>
       </div>

--- a/app/contact/page.tsx
+++ b/app/contact/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 
 export const metadata: Metadata = {
   title: "Contact",
-  description: "Get in touch with Club Fore.",
+  description: "Get in touch with Courtier.",
   openGraph: { images: ["/opengraph-image"] },
   twitter: { images: ["/twitter-image"] }
 };

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,9 +4,9 @@ import { Navbar } from "@/components/Navbar";
 import { Footer } from "@/components/Footer";
 
 export const metadata: Metadata = {
-  title: { default: "Club Fore", template: "%s · Club Fore" },
+  title: { default: "Courtier", template: "%s · Courtier" },
   description: "Precision. Power. Minimalism.",
-  openGraph: { title: "Club Fore", description: "Precision. Power. Minimalism.", images: ["/opengraph-image"] },
+  openGraph: { title: "Courtier", description: "Precision. Power. Minimalism.", images: ["/opengraph-image"] },
   twitter: { card: "summary_large_image", images: ["/twitter-image"] }
 };
 

--- a/app/membership/page.tsx
+++ b/app/membership/page.tsx
@@ -57,7 +57,7 @@ const plans: Plan[] = [
 export const metadata: Metadata = {
   title: "Membership",
   description:
-    "Membership at Club Fore is designed to fit how you play, with three tiers balancing access, flexibility, and community.",
+    "Membership at Courtier is designed to fit how you play, with three tiers balancing access, flexibility, and community.",
   openGraph: { images: ["/opengraph-image"] },
   twitter: { images: ["/twitter-image"] }
 };
@@ -84,7 +84,7 @@ export default function MembershipPage() {
           Membership
         </h1>
         <p className="max-w-2xl mx-auto text-lg text-white/80">
-          Membership at Club Fore is designed to fit how you play, with three tiers
+          Membership at Courtier is designed to fit how you play, with three tiers
           balancing access, flexibility, and community.
         </p>
       </header>

--- a/app/opengraph-image.tsx
+++ b/app/opengraph-image.tsx
@@ -21,7 +21,7 @@ export default function OpengraphImage() {
           gap: 40,
         }}
       >
-        <div style={{ fontSize: 128 }}>CLUB FORE</div>
+        <div style={{ fontSize: 128 }}>COURTIER</div>
         <div style={{ fontSize: 48, fontWeight: 400 }}>Precision. Power. Minimalism.</div>
       </div>
     ),

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import Hero from "@/components/Hero";
 
 export const metadata: Metadata = {
-  title: "Club Fore",
+  title: "Courtier",
   description: "Members-only padel. Designed in London.",
 };
 

--- a/app/twitter-image.tsx
+++ b/app/twitter-image.tsx
@@ -21,7 +21,7 @@ export default function TwitterImage() {
           gap: 40,
         }}
       >
-        <div style={{ fontSize: 128 }}>CLUB FORE</div>
+        <div style={{ fontSize: 128 }}>COURTIER</div>
         <div style={{ fontSize: 48, fontWeight: 400 }}>Precision. Power. Minimalism.</div>
       </div>
     ),

--- a/components/Hero.tsx
+++ b/components/Hero.tsx
@@ -207,7 +207,7 @@ export default function Hero() {
       }
       for (const seg of model.lines) drawSegment(seg[0], seg[1], S, cx, cy, 2, "#fff");
 
-      // Club Fore logo on far wall
+      // Courtier logo on far wall
       const logoPos = { x: COURT.L - 0.01, y: COURT.W / 2, z: 2.5 };
       const lp = project(logoPos, S, cx, cy);
       if (lp) {
@@ -218,7 +218,7 @@ export default function Hero() {
         ctx.textAlign = "center";
         ctx.textBaseline = "middle";
         ctx.font = `bold ${fontSize}px sans-serif`;
-        ctx.fillText("CLUB FORE", lp.x, lp.y);
+        ctx.fillText("COURTIER", lp.x, lp.y);
       }
 
       const netRes = 20;

--- a/components/Navbar.tsx
+++ b/components/Navbar.tsx
@@ -8,7 +8,7 @@ export function Navbar() {
     <header className="sticky top-0 z-50 bg-black/70 backdrop-blur border-b border-white/10">
       <div className="mx-auto max-w-6xl px-4 py-3 flex items-center justify-between text-white">
         <Link href="/" className="font-semibold tracking-widest text-xl focus:outline-white/60">
-          CLUB FORE
+          COURTIER
         </Link>
         <nav className="hidden md:flex gap-6 text-sm">
           <Link href="/about" className="focus:outline-white/60">

--- a/data/products.json
+++ b/data/products.json
@@ -2,15 +2,15 @@
   {
     "id": 1,
     "slug": "cap",
-    "name": "Club Fore Cap",
+    "name": "Courtier Cap",
     "price": 25,
-    "description": "Breathable performance cap with subtle Club Fore branding.",
+    "description": "Breathable performance cap with subtle Courtier branding.",
     "images": ["/CAP.png"]
   },
   {
     "id": 2,
     "slug": "shirt",
-    "name": "Club Fore Shirt",
+    "name": "Courtier Shirt",
     "price": 35,
     "description": "Lightweight moisture-wicking tee for training and match day.",
     "images": ["/SHIRT.png"]
@@ -26,7 +26,7 @@
   {
     "id": 4,
     "slug": "racket",
-    "name": "Club Fore Racket",
+    "name": "Courtier Racket",
     "price": 150,
     "description": "Balanced padel racket engineered for control and power.",
     "images": ["/RACKET.png"]
@@ -34,7 +34,7 @@
   {
     "id": 5,
     "slug": "hoodie",
-    "name": "Club Fore Hoodie",
+    "name": "Courtier Hoodie",
     "price": 60,
     "description": "Soft fleece hoodie with clean monochrome lines.",
     "images": ["/HOODIE.png"]

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "club-fore",
+  "name": "courtier",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "club-fore",
+      "name": "courtier",
       "version": "0.1.0",
       "dependencies": {
         "firebase-admin": "12.6.0",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "club-fore",
+  "name": "courtier",
   "private": true,
   "version": "0.1.0",
   "scripts": {

--- a/public/logo.svg
+++ b/public/logo.svg
@@ -1,3 +1,3 @@
 <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 100 20">
-  <text x="0" y="15" font-size="15" font-family="sans-serif">Club Fore</text>
+  <text x="0" y="15" font-size="15" font-family="sans-serif">COURTIER</text>
 </svg>

--- a/public/og.svg
+++ b/public/og.svg
@@ -1,4 +1,4 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="1200" height="630">
   <rect width="100%" height="100%" fill="black"/>
-  <text x="50%" y="50%" fill="white" font-size="120" font-family="sans-serif" font-weight="700" dominant-baseline="middle" text-anchor="middle">CLUB FORE</text>
+  <text x="50%" y="50%" fill="white" font-size="120" font-family="sans-serif" font-weight="700" dominant-baseline="middle" text-anchor="middle">COURTIER</text>
 </svg>


### PR DESCRIPTION
## Summary
- replace all on-site references to "Club Fore" with "Courtier" including metadata, navigation, and hero artwork
- refresh marketing copy, product data, and share images to reflect the new Courtier name
- update repository naming details such as the package name and README headline

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c92a5defbc8332a22a97ebbe0fe474